### PR TITLE
removed extra whitepace in front-matter

### DIFF
--- a/community/plugins.html
+++ b/community/plugins.html
@@ -1,8 +1,8 @@
---- 
+---
 layout: default 
 title: Plugins 
 subtitle: "Bundled and community contributed plugins" 
---- 
+---
 
 
 <p>	

--- a/contribute/contribution-guide.html
+++ b/contribute/contribution-guide.html
@@ -1,4 +1,4 @@
---- 
+---
 layout: default 
 title: Contribution Guide 
 ---

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -1,4 +1,4 @@
---- 
+---
 layout: default 
 title: Get started 
 ---

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
---- 
+---
 layout: home 
 title: Go - Continuous Delivery software 
 ---


### PR DESCRIPTION
These four files had extra whitespace on the end of the front matter delimiters. So, "--- " instead of "---". This caused Jekyll (at least on my machine) to completely ignore the front-matter and not render the files. 
