### PR TITLE
IE8 Javascript compatibility

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -19,14 +19,15 @@ jQuery(document).ready(function() {
     var doc = document.documentElement,
         body = document.body;
 
-    if (document.getElementsByClassName('leftnav')[0] != undefined){
-        var headerTop = document.getElementsByClassName('leftnav')[0].offsetTop;
-        window.addEventListener('scroll', function() {
+    if ($('.leftnav').length > 0) {
+        var leftNav = $('.leftnav')[0],
+            headerTop = $(leftNav).offset().top;
+        $(window).scroll(function() {
             var top = doc && doc.scrollTop || body && body.scrollTop || 0;
             if (top > headerTop)
-                document.getElementsByClassName('leftnav')[0].classList.add('fixedToTop')
+                $(leftNav).addClass('fixedToTop')
             else
-                document.getElementsByClassName('leftnav')[0].classList.remove('fixedToTop')
+                $(leftNav).removeClass('fixedToTop')
         });
     }
 


### PR DESCRIPTION
Due to some JS calls incompatible with IE8 relating to the sometimes-present fixed left hand side menu, a JS error prevented IE8 users from viewing more important content, notably the body of the Downloads page.

Screenshot before

![ie8-before](https://cloud.githubusercontent.com/assets/20520/4347844/bebfe566-416d-11e4-8e0a-ff236bd27ede.png)

Screenshot after

![ie8-after](https://cloud.githubusercontent.com/assets/20520/4347845/bec66ce2-416d-11e4-9d2c-529e871344f2.png)
