### PR TITLE
Changed the links to help Docs.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ navigation:
     - text: Why Go?
       url: /learn-more/why-go.html
     - text: Help Doc
-      url: http://www.thoughtworks.com/products/docs/go/current/help/
+      url: http://www.go.cd/documentation/user/current/
       target: blank
 - root: Contribute
   url: #

--- a/_posts/2014-02-24-build-promotion-go.markdown
+++ b/_posts/2014-02-24-build-promotion-go.markdown
@@ -48,7 +48,7 @@ Promoting builds at the press of a button is what turns the deployment pipeline 
 
 ###Model your promotion process into the CD tool
 
-In general, a build/deployment pipeline is also a promotion pipeline. Go’s support for pipelines and stages with automatic or manual approvals makes it easy to model and [visualize](http://www.thoughtworks.com/products/docs/go/13.3/help/value_stream_map.html) your promotion process into the [CD value stream](http://www.thoughtworks.com/insights/blog/how-do-i-do-cd-go-part-2-pipelines-and-value-streams). A stage runs only when the previous stage has passed - this is like an automatic promotion gate. [Manual](http://www.thoughtworks.com/products/docs/go/current/help/dev_choose_when_stage_runs.html) stage [approvals](http://www.thoughtworks.com/products/docs/go/current/help/dev_authorization.html#approvals) may also be used where needed.
+In general, a build/deployment pipeline is also a promotion pipeline. Go’s support for pipelines and stages with automatic or manual approvals makes it easy to model and [visualize](http://www.go.cd/documentation/user/current/navigation/value_stream_map.html) your promotion process into the [CD value stream](http://www.thoughtworks.com/insights/blog/how-do-i-do-cd-go-part-2-pipelines-and-value-streams). A stage runs only when the previous stage has passed - this is like an automatic promotion gate. [Manual](http://www.go.cd/documentation/user/current/configuration/dev_choose_when_stage_runs.html) stage [approvals](http://www.go.cd/documentation/user/current/configuration/dev_authorization.html#adding-authorization-to-approvals) may also be used where needed.
 
 ![](/images/blog/sriram-buildpromo1.png)
 
@@ -56,15 +56,15 @@ In general, a build/deployment pipeline is also a promotion pipeline. Go’s sup
 
 ###Go 13.3
 
-[Go 13.3](http://www.thoughtworks.com/products/docs/go/13.3/help/package_material.html) adds more support by letting you store your packages in a first-class external package repository and yet activating different promotion levels within the tool. We now have three ways of activating a promotion level manually or automatically:
+[Go 13.3](http://www.go.cd/documentation/user/current/configuration/package_material.html) adds more support by letting you store your packages in a first-class external package repository and yet activating different promotion levels within the tool. We now have three ways of activating a promotion level manually or automatically:
 
 1.   Stage n activating stage n+1
-1.   Pipeline X activating Pipeline Y [(pipeline dependency)](http://www.thoughtworks.com/products/docs/go/current/help/managing_dependencies.html)
+1.   Pipeline X activating Pipeline Y [(pipeline dependency)](http://www.go.cd/documentation/user/current/configuration/managing_dependencies.html)
 1.   Pipeline Y getting activated by the updation of a package in a package repository (package material dependency)
 
-There are situations when we could use either #2 or #3 above to model a promotion. The [package material](http://www.thoughtworks.com/products/docs/go/13.3/help/package_material.html#vsm) docs has a section on this.
+There are situations when we could use either #2 or #3 above to model a promotion. The [package material](http://www.go.cd/documentation/user/current/configuration/package_material.html#value-stream-modeling-tip) docs has a section on this.
 
-Support for package material has been implemented as an extension point. Plugins written to this extension point can provide support for different types of repositories. A [yum plugin](http://www.thoughtworks.com/products/docs/go/13.3/help/yum_repository_poller.html) is bundled along with Go Server 13.3. Other non-bundled package material plugins are [listed here](http://thoughtworksinc.github.io/go-external-plugins/).
+Support for package material has been implemented as an extension point. Plugins written to this extension point can provide support for different types of repositories. A [yum plugin](http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html) is bundled along with Go Server 13.3. Other non-bundled package material plugins are [listed here](http://thoughtworksinc.github.io/go-external-plugins/).
 
 Happy packaging and promoting!
 

--- a/_posts/2014-02-24-go-template-permissions.markdown
+++ b/_posts/2014-02-24-go-template-permissions.markdown
@@ -22,7 +22,7 @@ Then, click the "Permissions" link for the template, you want to manage permissi
 
 ![](/images/blog/Permissions1.png)
 
-More information on this is available in the [13.4 help documentation](http://www.thoughtworks.com/products/docs/go/13.4/help/pipeline_templates.html#edit_template).
+More information on this is available in the [13.4 help documentation](http://www.go.cd/documentation/user/current/configuration/pipeline_templates.html#editing-pipeline-templates).
 
 
 <div class="highlight">This post is also cross-posted <a href="http://www.thoughtworks.com/insights/blog/go-template-permissions">here</a>.</div>

--- a/_posts/2014-02-24-how-peg-your-pipeline-dependency-version.markdown
+++ b/_posts/2014-02-24-how-peg-your-pipeline-dependency-version.markdown
@@ -28,14 +28,14 @@ On the face of it, it may appear that Go cannot support pegging. But that is not
 ![](/images/blog/sriram-peg2.png)
 
 
-“manual-gate” is a simple pipeline with one stage having a single no-op job, one upstream dependency C1, and [auto-scheduling turned off](http://www.thoughtworks-studios.com/docs/go/current/help/configuration_reference.html#approval) (this makes d3 static rather than fluid). The manual gate doesn’t trigger for every successful run of C1, it can only be manually triggered. C2 has a regular fluid dependency (d4) with manual-gate. The overall setup pegs C2 to a chosen good version of C1 while C1 is free to keep building new versions.
+“manual-gate” is a simple pipeline with one stage having a single no-op job, one upstream dependency C1, and [auto-scheduling turned off](http://www.go.cd/documentation/user/current/configuration/configuration_reference.html#approval) (this makes d3 static rather than fluid). The manual gate doesn’t trigger for every successful run of C1, it can only be manually triggered. C2 has a regular fluid dependency (d4) with manual-gate. The overall setup pegs C2 to a chosen good version of C1 while C1 is free to keep building new versions.
 
 
 ###Rolling back
 
-Say C2 is pegged to version 100 of C1. A week passes and C1 has progressed to 110. To get in sync with latest again, we simply trigger the manual-gate. The manual-gate itself is a no-op so it turns green and triggers C2. C2 does a [fetch-ancestor-artifact](http://www.thoughtworks-studios.com/docs/go/current/help/managing_dependencies.html#fetch_artifact_section) to get C1 binary version 110 and proceeds to build. If the build turns green, it means we have successfully pegged C2 to version 110 of C1. What if the build fails?
+Say C2 is pegged to version 100 of C1. A week passes and C1 has progressed to 110. To get in sync with latest again, we simply trigger the manual-gate. The manual-gate itself is a no-op so it turns green and triggers C2. C2 does a [fetch-ancestor-artifact](http://www.go.cd/documentation/user/current/configuration/managing_dependencies.html#fetching-artifacts-from-an-upstream-pipeline) to get C1 binary version 110 and proceeds to build. If the build turns green, it means we have successfully pegged C2 to version 110 of C1. What if the build fails?
 
-We have two options. We could revert to last known good version by [retriggering manual gate with version](http://www.thoughtworks-studios.com/docs/go/current/help/trigger_with_options.html) 100 of C1. Or we could keep bisecting the range between 100 and 110 to find the most recent version of C1 that works for C2.
+We have two options. We could revert to last known good version by [retriggering manual gate with version](http://www.go.cd/documentation/user/current/advanced_usage/trigger_with_options.html) 100 of C1. Or we could keep bisecting the range between 100 and 110 to find the most recent version of C1 that works for C2.
 
 
 <div class="highlight">This post is also cross-posted <a href="http://www.thoughtworks.com/insights/blog/how-peg-your-pipeline-dependency-version">here</a>.</div>

--- a/_posts/2014-03-06-hello-world-with-go.markdown
+++ b/_posts/2014-03-06-hello-world-with-go.markdown
@@ -7,7 +7,7 @@ published: true
 author: Ken Mugrage
 ---
 
-In a few steps you'll see an example of a simple one stage pipeline in Go. This is definitely not meant to be a definitive guide, just a basic introduction to how Go works. It's definitely a good idea to peruse [the concepts section](http://www.thoughtworks.com/products/docs/go/current/help/concepts_in_go.html) go Go's help to understand some of the terms you'll see (like pipeline and stage).
+In a few steps you'll see an example of a simple one stage pipeline in Go. This is definitely not meant to be a definitive guide, just a basic introduction to how Go works. It's definitely a good idea to peruse [the concepts section](http://www.go.cd/documentation/user/current/introduction/concepts_in_go.html) go Go's help to understand some of the terms you'll see (like pipeline and stage).
 
 *I am assuming you've installed Go Server AND a Go Agent. You need both!* I'm also assuming you have some source code in a version control system that you want to build.
 

--- a/_posts/2014-04-24-source-code-for-go-now-available.markdown
+++ b/_posts/2014-04-24-source-code-for-go-now-available.markdown
@@ -17,7 +17,7 @@ If you’d like to contribute to Go, please check out the guide which can be fou
 
 ### New plugin end-point available
 
-We’re also releasing Go 14.1, which now includes the ability to write your own custom task plugins. Is there a system you want to manage with Go but you’d prefer not to create command line scripts? Creating a plug-in could be a great way to extend Go without the need to modify the core source code. Check out [http://www.thoughtworks.com/products/docs/go/14.1.0/help/whats_new_in_go.html](http://www.thoughtworks.com/products/docs/go/14.1.0/help/whats_new_in_go.html) for more information.
+We’re also releasing Go 14.1, which now includes the ability to write your own custom task plugins. Is there a system you want to manage with Go but you’d prefer not to create command line scripts? Creating a plug-in could be a great way to extend Go without the need to modify the core source code. Check out [Whats_new_in_Go](http://www.go.cd/documentation/user/current/release_history/whats_new_in_go.html) for more information.
 
 ### Current post-merge process
 

--- a/_posts/2014-05-18-manage-agents-with-docker.markdown
+++ b/_posts/2014-05-18-manage-agents-with-docker.markdown
@@ -68,7 +68,7 @@ agents for me, they won't be able to connect if you don't make this match your G
 - __autoregister.properties__
 
 This file takes advantage of the autoregister feature in Go so that I don't have to manually approve the new agents. You'll 
-need to update the key based on the instructions at [http://www.thoughtworks.com/products/docs/go/current/help/agent\_auto\_register.html](http://www.thoughtworks.com/products/docs/go/current/help/agent_auto_register.html)
+need to update the key based on the instructions at [http://www.go.cd/documentation/user/current/advanced_usage/agent_auto_register.html](http://www.go.cd/documentation/user/current/advanced_usage/agent_auto_register.html)
 
 - __build\_docker\_image.sh__
 

--- a/_posts/2014-08-19-cloning-templates.markdown
+++ b/_posts/2014-08-19-cloning-templates.markdown
@@ -12,7 +12,7 @@ When using GO for Continuous Delivery with multiple teams where you have various
 We have decided to have one deployment template separate per application / security group (Pipeline group) so we distribute maintenance, but also reduce the risk of breaking Pipelines of other teams when we change a base template. Having different templates also allows us to allocate [Template Admins](http://www.go.cd/2014/02/24/go-template-permissions.html) specific for the application / team / security group that now can manage most of the needs of a team without requiring Go System Admin rights. 
 
 As you don't want team to get Admin access across multiple applications but you still want them to have something to start with (a base template), we have created two Basic templates that cover basic needs for an application deployment that we "Clone" for each team. After cloning we assign an Admin from their team so they can start modifying it according to their own flavour. Cloning templates is not available in GO at the moment, so we had to find a way around it. 
-One [contributor](https://github.com/oanastoia) created a script that interacts with GO's own [Configuration API](http://www.thoughtworks.com/products/docs/go/current/help/Configuration_API.html]) to allow template cloning. 
+One [contributor](https://github.com/oanastoia) created a script that interacts with GO's own [Configuration API](http://www.go.cd/documentation/user/current/api/configuration_api.html) to allow template cloning. 
 
 ###How to setup cloning in your GO server instance
 1. Make sure you have access to [https://github.com/oanastoia/go-config-management.git](https://github.com/oanastoia/go-config-management.git), otherwise you will need to clone this repository inside your infrastructure
@@ -26,13 +26,13 @@ In this section I will try to cover with screenshots the steps you need to achie
 ####Create a new template group 
 Create a new template group for your "Administrative" tasks that you give permissions only to the persons you want to use the cloning. This will be useful if you decide to have more "configuration" type of pipelines. 
 In our organisation we have a "tooling" repository we use to wrap complex scripts to use in our tasks.
-I will not go into detail on how to achieve this, but you can read more on how to [specify permissions for pipeline groups](http://www.thoughtworks.com/products/docs/go/current/help/dev_authorization.html#pipeline-groups).
+I will not go into detail on how to achieve this, but you can read more on how to [specify permissions for pipeline groups](http://www.go.cd/documentation/user/current/configuration/dev_authorization.html#specifying-permissions-for-pipeline-groups).
 
 ####Create a new pipeline within this group
-1. You will need to [create new pipeline](http://www.thoughtworks.com/products/docs/go/current/help/quick_pipeline_setup.html) within this group. 
+1. You will need to [create new pipeline](http://www.go.cd/documentation/user/current/configuration/quick_pipeline_setup.html) within this group. 
 1. You will need to use Git as Material Type and under the URL, use the location of the cloning script (https://github.com/oanastoia/go-config-management.git if you have access to it, or the location where you cloned it). Use "Check Connection" to test it out.
 1. You will need to add two Environment Variables: SOURCE\_TEMPLATE and DESTINATION\_TEMPLATE that have some default values
-1. You will need to add two Secure Environment Variables: API\_USER and API\_PASS that contain credentials for a user that has correct permissions to use the [Configuration API](http://www.thoughtworks.com/products/docs/go/current/help/Configuration_API.html)
+1. You will need to add two Secure Environment Variables: API\_USER and API\_PASS that contain credentials for a user that has correct permissions to use the [Configuration API](http://www.go.cd/documentation/user/current/api/configuration_api.html)
 
 ![](/images/blog/cloning-templates/environment-variable-view.png)
 

--- a/community/plugins.html
+++ b/community/plugins.html
@@ -6,11 +6,11 @@ subtitle: "Bundled and community contributed plugins"
 
 
 <p>	
-Go publishes a list of extension points for which plugins can be provided. An extension point defines the interface and the lifecycle that governs the respective plugin. At present only java based extension points and plugins are supported by Go. Details about available extension points and their lifecycle can be obtained from <a href="http://www.thoughtworks.com/products/docs/go/current/help/go_plugins_basics.html">plugins documentation</a> along with the <a href="http://www.thoughtworks.com/products/docs/go/current/help/resources/javadoc/index.html">Go plugin API reference</a>. 
+Go publishes a list of extension points for which plugins can be provided. An extension point defines the interface and the lifecycle that governs the respective plugin. At present only java based extension points and plugins are supported by Go. Details about available extension points and their lifecycle can be obtained from <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html">plugins documentation</a> along with the <a href="http://www.go.cd/documentation/user/current/resources/javadoc/index.html">Go plugin API reference</a>. 
 </p>
 
 <p>
-Below is the listing of bundled as well as other available plugins contributed by the community (that are not bundled with the Go Server as yet).  Please refer the <a href="http://www.thoughtworks.com/products/docs/go/current/help/plugin_user_guide.html">plugin user guide</a> to know more about plugin installation etc.
+Below is the listing of bundled as well as other available plugins contributed by the community (that are not bundled with the Go Server as yet).  Please refer the <a href="http://www.go.cd/documentation/user/current/extension_points/plugin_user_guide.html">plugin user guide</a> to know more about plugin installation etc.
 </p>
 
 <div class="highlight" >
@@ -28,7 +28,7 @@ Below is the listing of bundled as well as other available plugins contributed b
 	    <h5 class="name">Yum repository poller</h5>
 	    <div class="more_details">
 	    	An Yum respository poller is a bundled package material plugin...
-	    	<a href="http://www.thoughtworks.com/products/docs/go/current/help/yum_repository_poller.html">Read more</a>
+	    	<a href="http://www.go.cd/documentation/user/current/extension_points/yum_repository_poller.html">Read more</a>
 	    </div>
 	    <div>by <a href="http://www.thoughtworks.com/products/">ThoughtWorks Inc.</a>
 	    </div>
@@ -134,8 +134,8 @@ Below is the listing of bundled as well as other available plugins contributed b
 
 	<li class="grid-3 contribute_tile">	
 		<h5 style='text-align:center; margin-top:20px;'><i class='icon-star-1'></i> <br/>Want to contribute?</h5>
-		<div><a href="http://www.thoughtworks.com/products/docs/go/current/help/writing_go_package_material_plugin.html"><i class='icon-code-1'></i>Write a plugin</a></div>
-		<div><a href="http://www.thoughtworks.com/products/docs/go/current/help/resources/javadoc/index.html"><i class='icon-book-1'></i>Go plugin API reference</a></div>
+		<div><a href="http://www.go.cd/documentation/user/current/extension_points/writing_go_package_material_plugin.html"><i class='icon-code-1'></i>Write a plugin</a></div>
+		<div><a href="http://www.go.cd/documentation/user/current/resources/javadoc/index.html"><i class='icon-book-1'></i>Go plugin API reference</a></div>
 	</li>
 </ul>
 
@@ -212,8 +212,8 @@ Below is the listing of bundled as well as other available plugins contributed b
 
 	<li class="grid-3 contribute_tile">	
 		<h5 style='text-align:center; margin-top:20px;'><i class='icon-star-1'></i> <br/>Want to contribute?</h5>
-		<div><a href="http://www.thoughtworks.com/products/docs/go/current/help/writing_go_task_plugins.html"><i class="icon-code-1"></i>Write a plugin</a></div>
-		<div><a href="http://www.thoughtworks.com/products/docs/go/current/help/resources/javadoc/index.html"><i class='icon-book-1'></i>Go plugin API reference</a></div>
+		<div><a href="http://www.go.cd/documentation/user/current/extension_points/writing_go_task_plugins.html"><i class="icon-code-1"></i>Write a plugin</a></div>
+		<div><a href="http://www.go.cd/documentation/user/current/resources/javadoc/index.html"><i class='icon-book-1'></i>Go plugin API reference</a></div>
 	</li>
 </ul>
 

--- a/community/resources.markdown
+++ b/community/resources.markdown
@@ -6,11 +6,11 @@ subtitle:  "Go Community Resources"
 
 ### User Documentation
 
-- <a href=http://www.thoughtworks.com/products/docs/go/current/help/>Welcome to Go</a> - Information on how to set up, use and administer Go can be found here
+- <a href=http://www.go.cd/documentation/user/current/>Welcome to Go</a> - Information on how to set up, use and administer Go can be found here
 
 ### Developer Documentation
 
-- <a href="http://www.thoughtworks.com/products/docs/go/current/help/go_api.html">Go APIs</a> - Documentation on using the RESTful Go APIs
+- <a href="http://www.go.cd/documentation/user/current/api/go_api.html">Go APIs</a> - Documentation on using the RESTful Go APIs
 - <a href="http://www.go.cd/documentation/developer">Go Documentation</a> (In progress) - Documentation describing the development environment, technology stack and architecture of Go. 
 - <a href="/contribute/cla.html">Contributor License Agreement</a> - If you would like to contribute back to Go you'll need to electronically sign this agreement
 

--- a/contribute/contribution-guide.html
+++ b/contribute/contribution-guide.html
@@ -89,7 +89,7 @@ title: Contribution Guide
             <p>Answering <a href="http://stackoverflow.com/questions/tagged/thoughtworks-go">stackoverflow</a> questions</p>
         </li>
         <li>
-            <p>Help improve <a href="http://www.thoughtworks.com/products/docs/go/current/help/">user docs</a>, <a href="https://github.com/gocd/documentation">design docs</a> etc.</p>
+            <p>Help improve <a href="http://www.go.cd/documentation/user/current/">user docs</a>, <a href="https://github.com/gocd/documentation">design docs</a> etc.</p>
         </li>
     </ul>
 
@@ -196,7 +196,7 @@ title: Contribution Guide
     <a name="make-sure-there-is-an-issue-logged-for-it"></a><h4>Make sure there is an <a href="https://github.com/gocd/gocd/issues">issue</a> logged for it.</h4>
     <p>When you talk to us about it we will make sure the issue is logged and assigned to you. You should use this issue number in your commit message &amp; pull request comment.</p>
     <a name="write-tests-then-code"></a><h4>Write Tests &amp; Then Code</h4>
-    <p>Understand the feature by reading <a href="http://www.thoughtworks.com/products/docs/go/current/help/">user docs</a> &amp; <a href="https://github.com/gocd/documentation">design docs</a>.</p>
+    <p>Understand the feature by reading <a href="http://www.go.cd/documentation/user/current/">user docs</a> &amp; <a href="https://github.com/gocd/documentation">design docs</a>.</p>
     <p>Debug the flow to make sure you understand the code fully.</p>
     <p>Follow <a href="http://en.wikipedia.org/wiki/Test-driven_development">Test Driven Development</a> (TDD) while you write code. i.e. if you are:</p>
     <ul>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -30,7 +30,7 @@ title: Get started
             <a class="icon-book" href="https://github.com/gocd/documentation">Go Dev Documentation</a>
         </li>
         <li>
-            <a class="icon-book-1" href="http://www.thoughtworks.com/products/docs/go/current/help/">Go User Documentation</a>
+            <a class="icon-book-1" href="http://www.go.cd/documentation/user/current/">Go User Documentation</a>
         </li>
     </ul>
 </div>
@@ -44,7 +44,7 @@ title: Get started
         <li>Submitting <a href="https://github.com/gocd/gocd/issues">issues</a></li>
         <li>Participating on <a href="https://groups.google.com/forum/#!forum/go-cd">user's group</a> &amp; <a href="https://groups.google.com/forum/#!forum/go-cd-dev">developer's group</a></li>
         <li>Answering <a href="http://stackoverflow.com/questions/tagged/thoughtworks-go">stackoverflow</a> questions</li>
-        <li>Helping us improve <a href="http://www.thoughtworks.com/products/docs/go/current/help/">user docs</a>, <a href="https://github.com/gocd/documentation">design docs</a> etc.</li>
+        <li>Helping us improve <a href="http://www.go.cd/documentation/user/current/">user docs</a>, <a href="https://github.com/gocd/documentation">design docs</a> etc.</li>
     </ul>
 </div>
 <div class="grid-4 road-map">

--- a/download/index.html
+++ b/download/index.html
@@ -5,7 +5,7 @@ subtitle: Download Go Server and Go Agent for Free
 ---
 
 
-<p> <b>You need to download both the <a href="http://www.thoughtworks.com/products/docs/go/current/help/installing_go_server.html">server</a> and the <a href="http://www.thoughtworks.com/products/docs/go/current/help/installing_go_agent.html">agent</a> in order to use Go.</b>
+<p> <b>You need to download both the <a href="http://www.go.cd/documentation/user/current/installation/installing_go_server.html">server</a> and the <a href="http://www.go.cd/documentation/user/current/installation/installing_go_agent.html">agent</a> in order to use Go.</b>
 </p>
 
 <p>If you need help downloading, installing or using Go please join the <a href="https://groups.google.com/forum/#!forum/go-cd">Go Users Google Group</a>. ThoughtWorks also provides commercial help for Go. They can be reached at <a href="mailto:support@thoughtworks.com">support@thoughtworks.com</a>.</p>


### PR DESCRIPTION
- The links to help docs now point to gitbook - 'http://www.go.cd/documentation/user/current/'.
