### PR TITLE
Fix all documentation urls

### DIFF
--- a/source/partners.html.erb
+++ b/source/partners.html.erb
@@ -59,7 +59,7 @@ meta_keywords: "GoCD, continuous delivery, continuous delivery software, continu
       </figure>
     </div>
     <div class="col-md-9">
-      <a href="http://www.jfrog.com/">JFrog</a>
+      <a href="https://www.jfrog.com/">JFrog</a>
       <p>Creators of Artifactory binary repository manager and Bintray the social cloud platform for software distribution. JFrog remedies the issues faced by software developers and DevOps teams, allowing them to manage, host and control the flow of binary artifacts from development to production.</p>
     </div>
   </div>

--- a/source/plugins.html.erb
+++ b/source/plugins.html.erb
@@ -102,7 +102,7 @@ meta_keywords: "GoCD, continuous delivery, continuous delivery software, continu
 
                     <i class="fa fa-star"></i>
                     <h5>Want to contribute?</h5>
-                    <a href="http://www.go.cd/documentation/developer/writing_go_plugins/overview.html">Write a plugin</a>
+                    <a href="https://developer.go.cd/current/writing_go_plugins/overview.html">Write a plugin</a>
                   </div>
                 </li>
               </ul>

--- a/source/posts/2014-02-24-how-peg-your-pipeline-dependency-version.html.markdown.erb
+++ b/source/posts/2014-02-24-how-peg-your-pipeline-dependency-version.html.markdown.erb
@@ -34,14 +34,14 @@ On the face of it, it may appear that GoCD cannot support pegging. But that is n
 <%= image_tag "blog/sriram-peg2.png", {:title => "Introducing a manual gate to a pipeline", :alt => "Introducing a manual gate to a pipeline"} %>
 
 
-“manual-gate” is a simple pipeline with one stage having a single no-op job, one upstream dependency C1, and [auto-scheduling turned off](http://www.go.cd/documentation/user/current/configuration/configuration_reference.html#approval) (this makes d3 static rather than fluid). The manual gate doesn’t trigger for every successful run of C1, it can only be manually triggered. C2 has a regular fluid dependency (d4) with manual-gate. The overall setup pegs C2 to a chosen good version of C1 while C1 is free to keep building new versions.
+“manual-gate” is a simple pipeline with one stage having a single no-op job, one upstream dependency C1, and [auto-scheduling turned off](https://docs.go.cd/current/configuration/configuration_reference.html#approval) (this makes d3 static rather than fluid). The manual gate doesn’t trigger for every successful run of C1, it can only be manually triggered. C2 has a regular fluid dependency (d4) with manual-gate. The overall setup pegs C2 to a chosen good version of C1 while C1 is free to keep building new versions.
 
 
 ###Rolling back
 
-Say C2 is pegged to version 100 of C1. A week passes and C1 has progressed to 110. To get in sync with latest again, we simply trigger the manual-gate. The manual-gate itself is a no-op so it turns green and triggers C2. C2 does a [fetch-ancestor-artifact](http://www.go.cd/documentation/user/current/configuration/managing_dependencies.html#fetching-artifacts-from-an-upstream-pipeline) to get C1 binary version 110 and proceeds to build. If the build turns green, it means we have successfully pegged C2 to version 110 of C1. What if the build fails?
+Say C2 is pegged to version 100 of C1. A week passes and C1 has progressed to 110. To get in sync with latest again, we simply trigger the manual-gate. The manual-gate itself is a no-op so it turns green and triggers C2. C2 does a [fetch-ancestor-artifact](https://docs.go.cd/current/configuration/managing_dependencies.html#fetching-artifacts-from-an-upstream-pipeline) to get C1 binary version 110 and proceeds to build. If the build turns green, it means we have successfully pegged C2 to version 110 of C1. What if the build fails?
 
-We have two options. We could revert to last known good version by [retriggering manual gate with version](http://www.go.cd/documentation/user/current/advanced_usage/trigger_with_options.html) 100 of C1. Or we could keep bisecting the range between 100 and 110 to find the most recent version of C1 that works for C2.
+We have two options. We could revert to last known good version by [retriggering manual gate with version](https://docs.go.cd/current/advanced_usage/trigger_with_options.html) 100 of C1. Or we could keep bisecting the range between 100 and 110 to find the most recent version of C1 that works for C2.
 
 
 <div class="highlight">This post is also cross-posted <a href="http://www.thoughtworks.com/insights/blog/how-peg-your-pipeline-dependency-version">here</a>.</div>

--- a/source/posts/2014-05-18-manage-agents-with-docker.html.markdown.erb
+++ b/source/posts/2014-05-18-manage-agents-with-docker.html.markdown.erb
@@ -75,7 +75,7 @@ agents for me, they won't be able to connect if you don't make this match your G
 - __autoregister.properties__
 
 This file takes advantage of the autoregister feature in GoCD so that I don't have to manually approve the new agents. You'll 
-need to update the key based on the instructions at [http://www.go.cd/documentation/user/current/advanced_usage/agent_auto_register.html](http://www.go.cd/documentation/user/current/advanced_usage/agent_auto_register.html)
+need to update the key based on the instructions at [https://docs.go.cd/current/advanced_usage/agent_auto_register.html](https://docs.go.cd/current/advanced_usage/agent_auto_register.html)
 
 - __build\_docker\_image.sh__
 

--- a/source/posts/2014-08-19-cloning-templates.html.markdown.erb
+++ b/source/posts/2014-08-19-cloning-templates.html.markdown.erb
@@ -17,7 +17,7 @@ When using GO for Continuous Delivery with multiple teams where you have various
 We have decided to have one deployment template separate per application / security group (Pipeline group) so we distribute maintenance, but also reduce the risk of breaking Pipelines of other teams when we change a base template. Having different templates also allows us to allocate [Template Admins](http://www.go.cd/2014/02/24/go-template-permissions.html) specific for the application / team / security group that now can manage most of the needs of a team without requiring GoCD System Admin rights. 
 
 As you don't want team to get Admin access across multiple applications but you still want them to have something to start with (a base template), we have created two Basic templates that cover basic needs for an application deployment that we "Clone" for each team. After cloning we assign an Admin from their team so they can start modifying it according to their own flavour. Cloning templates is not available in GO at the moment, so we had to find a way around it. 
-One [contributor](https://github.com/oanastoia) created a script that interacts with GO's own [Configuration API](http://www.go.cd/documentation/user/current/api/configuration_api.html) to allow template cloning. 
+One [contributor](https://github.com/oanastoia) created a script that interacts with GO's own [Configuration API](https://docs.go.cd/current/api/configuration_api.html) to allow template cloning. 
 
 ###How to setup cloning in your GO server instance
 1. Make sure you have access to [https://github.com/oanastoia/go-config-management.git](https://github.com/oanastoia/go-config-management.git), otherwise you will need to clone this repository inside your infrastructure
@@ -31,13 +31,13 @@ In this section I will try to cover with screenshots the steps you need to achie
 ####Create a new template group 
 Create a new template group for your "Administrative" tasks that you give permissions only to the persons you want to use the cloning. This will be useful if you decide to have more "configuration" type of pipelines. 
 In our organisation we have a "tooling" repository we use to wrap complex scripts to use in our tasks.
-I will not go into detail on how to achieve this, but you can read more on how to [specify permissions for pipeline groups](http://www.go.cd/documentation/user/current/configuration/dev_authorization.html#specifying-permissions-for-pipeline-groups).
+I will not go into detail on how to achieve this, but you can read more on how to [specify permissions for pipeline groups](https://docs.go.cd/current/configuration/dev_authorization.html#specifying-permissions-for-pipeline-groups).
 
 ####Create a new pipeline within this group
-1. You will need to [create new pipeline](http://www.go.cd/documentation/user/current/configuration/quick_pipeline_setup.html) within this group. 
+1. You will need to [create new pipeline](https://docs.go.cd/current/configuration/quick_pipeline_setup.html) within this group. 
 1. You will need to use Git as Material Type and under the URL, use the location of the cloning script (https://github.com/oanastoia/go-config-management.git if you have access to it, or the location where you cloned it). Use "Check Connection" to test it out.
 1. You will need to add two Environment Variables: SOURCE\_TEMPLATE and DESTINATION\_TEMPLATE that have some default values
-1. You will need to add two Secure Environment Variables: API\_USER and API\_PASS that contain credentials for a user that has correct permissions to use the [Configuration API](http://www.go.cd/documentation/user/current/api/configuration_api.html)
+1. You will need to add two Secure Environment Variables: API\_USER and API\_PASS that contain credentials for a user that has correct permissions to use the [Configuration API](https://docs.go.cd/current/api/configuration_api.html)
 
 <%= image_tag "blog/cloning-templates/environment-variable-view.png", {:title => "Environment Variables view", :alt => "Environment Variables view"} %>
 

--- a/source/posts/2015-04-27-Feature-Branch-Support.html.markdown.erb
+++ b/source/posts/2015-04-27-Feature-Branch-Support.html.markdown.erb
@@ -75,8 +75,8 @@ you have more hardware (agents) to run branch builds.
 ### The way forward
 
 Assuming you have chosen the approach mentioned above, you can now use GoCD 15.1, with its two new extension points - [SCM
-end-point](http://www.go.cd/documentation/user/15.1.0/extension_points/scm_extension.html) and the [Notification
-end-point](http://www.go.cd/documentation/user/15.1.0/extension_points/notification_extension.html), to test feature
+end-point](https://docs.go.cd/15.1.0/extension_points/scm_extension.html) and the [Notification
+end-point](https://docs.go.cd/15.1.0/extension_points/notification_extension.html), to test feature
 branches before they are merged.
 
 To use this with GitHub requires the use of two community-driven and community-supported plugins: [Git Branch Poller

--- a/source/posts/2015-05-06-Getting-Started-Resources.html.markdown.erb
+++ b/source/posts/2015-05-06-Getting-Started-Resources.html.markdown.erb
@@ -24,7 +24,7 @@ There are a couple sections of the user documentation that can be especially hel
 * [Setting up a new Pipeline](https://www.go.cd/getting-started/part-1) - See how to set up your first pipeline
 * [Concepts in GoCD](https://docs.go.cd/current/introduction/concepts_in_go.html) - This covers some of the
   basic concepts used in GoCD. A good understanding of what Pipelines, Stages, Jobs and Tasks are will be very helpful.
-* [Managing Agents](http://www.go.cd/documentation/user/current/configuration/managing_a_build_cloud.html) - The GoCD server
+* [Managing Agents](https://docs.go.cd/current/configuration/managing_a_build_cloud.html) - The GoCD server
   produces the user interface for GoCD, but it doesn't actually run your jobs. Learn how to use GoCD Agents to "do the work".
 
 Of course there's a lot more information available as well.

--- a/source/posts/2015-06-18-authentication-end-point.html.markdown.erb
+++ b/source/posts/2015-06-18-authentication-end-point.html.markdown.erb
@@ -13,7 +13,7 @@ meta_keywords: "GoCD, continuous delivery, continuous delivery software, continu
 date: 2015-06-18T00:00:00+00:00
 ---
 
-Starting 15.2.0 GoCD Server will expose authentication end-point. What this means is GoCD users can add "custom" authentication schemes through plugins. With [plugin settings](http://www.go.cd/documentation/developer/writing_go_plugins/plugin_settings/plugin_settings_overview.html) & [web request handling ability](http://www.go.cd/documentation/developer/writing_go_plugins/handling_web_requests.html) plugin developers get enough flexibility to write any authentication plugin they intend to write.
+Starting 15.2.0 GoCD Server will expose authentication end-point. What this means is GoCD users can add "custom" authentication schemes through plugins. With [plugin settings](https://developer.go.cd/current/writing_go_plugins/plugin_settings/plugin_settings_overview.html) & [web request handling ability](https://developer.go.cd/current/writing_go_plugins/handling_web_requests.html) plugin developers get enough flexibility to write any authentication plugin they intend to write.
 
 Examples of integrations possible:
 
@@ -86,7 +86,7 @@ We hope plugin developers are able to use this feature to support their organiza
 
 #### References:
 
-* [Developer Docs](http://www.go.cd/documentation/developer/writing_go_plugins/authentication/authentication_plugin_overview.html)
+* [Developer Docs](https://developer.go.cd/current/writing_go_plugins/authentication/authentication_plugin_overview.html)
 * [GitHub Issue](https://github.com/gocd/gocd/issues/851)
 * [Sample Plugins](http://www.go.cd/community/plugins.html#authentication-plugins)
 

--- a/source/posts/2015-06-18-plugin-settings.html.markdown.erb
+++ b/source/posts/2015-06-18-plugin-settings.html.markdown.erb
@@ -45,7 +45,7 @@ We hope plugin developers are able to use this feature to provide a better exper
 
 #### References:
 
-* Dev Docs - [Plugin Settings](http://www.go.cd/documentation/developer/writing_go_plugins/plugin_settings/plugin_settings_overview.html), [Application Accessor](http://www.go.cd/documentation/developer/writing_go_plugins/go_application_accessor/plugin_settings/version_1_0/get_plugin_settings.html)
+* Dev Docs - [Plugin Settings](https://developer.go.cd/current/writing_go_plugins/plugin_settings/plugin_settings_overview.html), [Application Accessor](https://developer.go.cd/current/writing_go_plugins/go_application_accessor/plugin_settings/version_1_0/get_plugin_settings.html)
 * [GitHub Issue](https://github.com/gocd/gocd/issues/1121)
 * [Sample Plugin - Email Notifier](https://github.com/srinivasupadhya/email-notifier)
 

--- a/source/posts/2015-07-07-GitHub-Integration.html.markdown.erb
+++ b/source/posts/2015-07-07-GitHub-Integration.html.markdown.erb
@@ -52,7 +52,7 @@ The combination of these plugins will help you configure GoCD such that any pull
 
 ---
 
-# GitHub Issues Integration with [Custom Project Management Setup](http://www.go.cd/documentation/user/current/integration/go_integration.html#integration-with-bug-tracking-and-story-management-tools)
+# GitHub Issues Integration with [Custom Project Management Setup](https://docs.go.cd/current/integration/go_integration.html#integration-with-bug-tracking-and-story-management-tools)
 
 Any commit messages that contain references to issues or pull requests using the popular means to mention issue (#42) can is something that GoCD already understands.
 

--- a/source/posts/2015-12-22-gocd-in-2016.html.markdown.erb
+++ b/source/posts/2015-12-22-gocd-in-2016.html.markdown.erb
@@ -87,7 +87,7 @@ GoCD’s getting started experience can definitely be better. As with everything
 these days, users’ expectations regarding their initial and continued
 experiences keeps changing. In GoCD’s world, I think one of the problems is that
 the domain of GoCD’s
-[concepts](http://www.go.cd/documentation/user/current/introduction/concepts_in_go.html)
+[concepts](https://docs.go.cd/current/introduction/concepts_in_go.html)
 takes getting used to. Other problems include a not-so-easy installation and
 evaluation experience, better documentation targeted towards a new user ("How do
 I create my first pipeline?"), better dashboard UI, a much better

--- a/source/posts/2015-12-28-gocd-continuous-delivery-through-pipelines.html.markdown.erb
+++ b/source/posts/2015-12-28-gocd-continuous-delivery-through-pipelines.html.markdown.erb
@@ -65,7 +65,7 @@ Go server artifacts (artifacts can grow over time and problems may occur). In se
 configuration, there is also an admin tab for URL configuration. We needed to get feedback
 on failing builds, so we integrated Go with LDAP so each user of Go had an email and could
 subscribe on build information based on preferred filters.
-Here is a [link](https://www.go.cd/documentation/user/current/configuration/dev_authentication.html)
+Here is a [link](https://docs.go.cd/current/configuration/dev_authentication.html)
 which explains the authentication process.
 
 It is worth mentioning that GoCD has a powerful API for power users where the entire

--- a/source/posts/2016-02-08-not-done-unless-its-done-security.html.markdown.erb
+++ b/source/posts/2016-02-08-not-done-unless-its-done-security.html.markdown.erb
@@ -29,7 +29,7 @@ meta_keywords: "GoCD, continuous delivery, continuous delivery software, continu
 
 ##Automation is one part of the solution
 
-Security has to be addressed in a holistic way. Automation is a way to get fast feedback on common security issues. A talented [penetration tester](http://security.stackexchange.com/a/46028) will consider scenarios and methods that are not usually automated.
+Security has to be addressed in a holistic way. Automation is a way to get fast feedback on common security issues. A talented [penetration tester](http://security.stackexchange.com/questions/46021/what-is-a-pen-tester/46028#46028) will consider scenarios and methods that are not usually automated.
 
 The goal of automation is to catch the “low-hanging fruit”. Are we pushing things to Git we shouldn’t be? Are we using an old, vulnerable package we shouldn’t? Are we violating our own company’s rules?
 

--- a/source/posts/2016-02-08-not-done-unless-its-done-security.html.markdown.erb
+++ b/source/posts/2016-02-08-not-done-unless-its-done-security.html.markdown.erb
@@ -75,7 +75,7 @@ I believe security is one of the few areas where having specialists writing and 
 
 When people ask this question, they are usually trying to decide if security pipelines or stages should be blocking, meaning that the pipeline can’t move forward on failures. I definitely think they should block, but that doesn’t mean you can’t do other types of testing on the same build.
 
-If your continuous delivery server supports [fan-in / fan-out](https://www.go.cd/documentation/user/current/introduction/concepts_in_go.html#fan_in_out), you can set tests up as entirely separate pipelines that run while other pipelines (or people) are doing other things. In the example below, we’ve decided that we can go ahead with User Acceptance while the security scans are in progress. We still know that it won’t get deployed to our staging environment unless they both pass.
+If your continuous delivery server supports [fan-in / fan-out](https://docs.go.cd/current/introduction/concepts_in_go.html#fan_in_out), you can set tests up as entirely separate pipelines that run while other pipelines (or people) are doing other things. In the example below, we’ve decided that we can go ahead with User Acceptance while the security scans are in progress. We still know that it won’t get deployed to our staging environment unless they both pass.
 
 <img src="/assets/images/blog/deploy-now/continuous_delivery_security_testing_pipeline.png" alt="continuous delivery security testing pipeline" title="continuous delivery security testing pipeline">
 

--- a/source/releases.html.erb
+++ b/source/releases.html.erb
@@ -430,7 +430,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
             <h5>Setup hostname when auto-registering agents</h5>
             <p>
               You can now specify a property <code>agent.auto.register.hostname</code> to setup the hostname when
-              <a href='http://www.go.cd/documentation/user/current/advanced_usage/agent_auto_register.html'>auto-registering</a> an agent.
+              <a href='https://docs.go.cd/current/advanced_usage/agent_auto_register.html'>auto-registering</a> an agent.
             </p>
             <h4>API Improvements</h4>
             <p>
@@ -490,7 +490,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
             You’ll never need to wish that Go supported your favorite kind of material repository, you can implement support for it yourself!
           </p>
           <p>
-            You can see all the SCM material plugins on the <a href="http://www.go.cd/community/plugins#scm-plugins">Go community plugins page</a>. See how to write one, <a href="http://www.go.cd/documentation/user/current/extension_points/scm_extension.html">here</a>.
+            You can see all the SCM material plugins on the <a href="http://www.go.cd/community/plugins#scm-plugins">Go community plugins page</a>. See how to write one, <a href="https://docs.go.cd/current/extension_points/scm_extension.html">here</a>.
           </p>
           <p>
             Here’s how the GitHub pull requests plugin looks in action (below). Read more about it in this <a href="http://www.go.cd/2015/04/27/Feature-Branch-Support.html">blog post</a>. Watch out for more improvements in the UI around this area.
@@ -503,7 +503,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
           for quite a lot of use cases, and we are excited to see plugins written against this endpoint even before release (yay, open source!).</p>
           <p> <a href="https://github.com/matt-richardson">@matt-richardson</a> has written a really nice generic notification plugin, which sends build notifications to any websocket listener! <a href="https://github.com/ashwanthkumar">@ashwanthkumar</a>              has written a great plugin to notify Slack about build status changes. <a href="https://github.com/srinivasupadhya/">@srinivasupadhya</a> has written a couple of nice notification plugins to update pull request statuses in GitHub and Atlassian
         Stash.</p>
-        <p> You can see all of those plugins on the <a href="http://www.go.cd/community/plugins#notification-plugins">Go community plugins page</a>. See how to write one yourself, <a href="http://www.go.cd/documentation/user/current/extension_points/notification_extension.html">here</a>.</p>
+        <p> You can see all of those plugins on the <a href="http://www.go.cd/community/plugins#notification-plugins">Go community plugins page</a>. See how to write one yourself, <a href="https://docs.go.cd/current/extension_points/notification_extension.html">here</a>.</p>
         <h4>Pipeline label shortening</h4>
         <p> This contribution by <a href="https://github.com/alexschwartz">@alexschwartz</a> helps declutter the Go Dashboard, by allowing the pipeline label to be trimmed, per material. This feature is really useful when dealing with unwieldy 40 character
       SHAs in pipelines with git/mercurial materials in them. This feature allows this: </p>
@@ -514,7 +514,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
       <figure class="small_image">
         <%= image_tag "releases/15.1/15_1_new_pipeline_label.png", {:title => "New pipleine labels - Short", :alt => "New short pipleine labels"} %>
       </figure>
-      <p> Read more about this feature <a href="http://www.go.cd/documentation/user/current/configuration/admin_use_custom_pipeline_label.html#using-truncated-material-revisions">in the documentation.</a></p>
+      <p> Read more about this feature <a href="https://docs.go.cd/current/configuration/admin_use_custom_pipeline_label.html#using-truncated-material-revisions">in the documentation.</a></p>
       <h4>Timestamps in console logs</h4>
       <p> Starting from Go 15.1, Go’s console logs will have timestamps for every line. This is very useful for finding out long-running parts of tasks. Here’s how it looks:</p>
       <figure class="small_image">
@@ -540,12 +540,12 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
     <div class="content">
       <h4>New Features</h4>
       <ul>
-        <li><a href="https://github.com/gocd/gocd/issues/719">719</a> - JSON message based Plugin APIs (docs - <a href="http://www.go.cd/documentation/developer/writing_go_plugins/package_material/json_message_based_package_material_extension.html">package</a>,
-        <a href="http://www.go.cd/documentation/developer/writing_go_plugins/task/json_message_based_task_extension.html">task</a>)
+        <li><a href="https://github.com/gocd/gocd/issues/719">719</a> - JSON message based Plugin APIs (docs - <a href="https://developer.go.cd/current/writing_go_plugins/package_material/json_message_based_package_material_extension.html">package</a>,
+        <a href="https://developer.go.cd/current/writing_go_plugins/task/json_message_based_task_extension.html">task</a>)
       </li>
-      <li><a href="https://github.com/gocd/gocd/issues/44">44</a> - Revise how new pipelines appear under 'Personalize'. Thanks <a href="https://github.com/mmb">@mmb</a> for the contribution. (<a href="http://www.go.cd/documentation/user/14.4.0/navigation/pipelines_dashboard_page.html#personalize-pipelines-view">docs</a>)
+      <li><a href="https://github.com/gocd/gocd/issues/44">44</a> - Revise how new pipelines appear under 'Personalize'. Thanks <a href="https://github.com/mmb">@mmb</a> for the contribution. (<a href="https://docs.go.cd/14.4.0/navigation/pipelines_dashboard_page.html#personalize-pipelines-view">docs</a>)
     </li>
-    <li> <a href="https://github.com/gocd/gocd/pull/699">699</a> - Users can comment on pipeline run history. (<a href="http://www.go.cd/documentation/user/current/beta/comment_on_pipeline_run.html">docs</a>)<br/>Note: This feature needs some improvements
+    <li> <a href="https://github.com/gocd/gocd/pull/699">699</a> - Users can comment on pipeline run history. (<a href="https://docs.go.cd/current/beta/comment_on_pipeline_run.html">docs</a>)<br/>Note: This feature needs some improvements
     listed <a href="https://github.com/gocd/gocd/issues/707">here</a>. Therefore the feature is turned 'off' for this release. To turn 'on' the feature, see <a href="https://github.com/gocd/gocd/pull/766#issuecomment-66963529">details</a>.
     Thanks <a href="https://github.com/mmb">@mmb</a>, <a href="https://github.com/gajwani">@gajwani</a>,<a href="https://github.com/fkotsian">@fkotsian</a> &amp; <a href="https://github.com/bsnchan">@bsnchan</a>contribution.
   </li>
@@ -569,27 +569,27 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
 <h4>New Features</h4>
 <ul>
   <li>
-    <a href="https://github.com/gocd/gocd/pull/396">396</a> - Automate running 'X' instances of a particular job and achieve faster results by parallelization. (<a href="http://www.go.cd/documentation/user/current/advanced_usage/admin_spawn_multiple_jobs#run-x-instances-of-a-job">docs</a>)
+    <a href="https://github.com/gocd/gocd/pull/396">396</a> - Automate running 'X' instances of a particular job and achieve faster results by parallelization. (<a href="https://docs.go.cd/current/advanced_usage/admin_spawn_multiple_jobs#run-x-instances-of-a-job">docs</a>)
   </li>
   <li>
     <a href="https://github.com/gocd/gocd/pull/225">225</a>, <a href="https://github.com/gocd/gocd/pull/394">394</a> &amp; <a href="https://github.com/gocd/gocd/pull/395">395</a> - New APIs.
   </li>
   <ul>
-    <li><a href="http://www.go.cd/documentation/user/current/api/pipeline_api.html#pipeline-history">Pipeline History API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/stages_api.html#stage-history">Stage History API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/job_api.html#job-history">Job History API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/agent_api.html#agent-job-run-history">Agent Job Run History API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/materials_api.html#modifications-api">Material Modification Listing API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/configuration_api.html#config-repository-modification-listing-api">Configuration Repository Modification Listing API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/pipeline_group_api.html#config-listing-api">Pipeline Group Listing API</a></li>
-    <li><a href="http://www.go.cd/documentation/user/current/api/materials_api.html#config-listing-api">Material Listing API</a></li>
+    <li><a href="https://docs.go.cd/current/api/pipeline_api.html#pipeline-history">Pipeline History API</a></li>
+    <li><a href="https://docs.go.cd/current/api/stages_api.html#stage-history">Stage History API</a></li>
+    <li><a href="https://docs.go.cd/current/api/job_api.html#job-history">Job History API</a></li>
+    <li><a href="https://docs.go.cd/current/api/agent_api.html#agent-job-run-history">Agent Job Run History API</a></li>
+    <li><a href="https://docs.go.cd/current/api/materials_api.html#modifications-api">Material Modification Listing API</a></li>
+    <li><a href="https://docs.go.cd/current/api/configuration_api.html#config-repository-modification-listing-api">Configuration Repository Modification Listing API</a></li>
+    <li><a href="https://docs.go.cd/current/api/pipeline_group_api.html#config-listing-api">Pipeline Group Listing API</a></li>
+    <li><a href="https://docs.go.cd/current/api/materials_api.html#config-listing-api">Material Listing API</a></li>
   </ul>
 </ul>
 <h4>Enhancements</h4>
 <ul>
-  <li> <a href="https://github.com/gocd/gocd/pull/435">435</a> - Value Stream Map for a commit. (<a href="http://www.go.cd/documentation/user/current/navigation/value_stream_map#viewing-the-value-stream-map">docs</a>)
+  <li> <a href="https://github.com/gocd/gocd/pull/435">435</a> - Value Stream Map for a commit. (<a href="https://docs.go.cd/current/navigation/value_stream_map#viewing-the-value-stream-map">docs</a>)
 </li>
-<li><a href="https://github.com/gocd/gocd/pull/466">466</a> - Setting up e-mail notifications is now easier with 'any pipeline' and 'any stage' options. Thanks <a href="https://github.com/lcs777">@lcs777</a> for the contribution. (<a href="http://www.go.cd/documentation/user/current/configuration/dev_notifications.html">docs</a>)
+<li><a href="https://github.com/gocd/gocd/pull/466">466</a> - Setting up e-mail notifications is now easier with 'any pipeline' and 'any stage' options. Thanks <a href="https://github.com/lcs777">@lcs777</a> for the contribution. (<a href="https://docs.go.cd/current/configuration/dev_notifications.html">docs</a>)
 </li>
 <li><a href="https://github.com/gocd/gocd/pull/460">460</a> - Enhanced search which hide pipelines. Thanks <a href="https://github.com/ciotlosm">@ciotlosm</a> for the contribution.</li>
 <li><a href="https://github.com/gocd/gocd/pull/310">310</a> - Plugin logger now allows logging exceptions. Thanks <a href="https://github.com/tusharm">@tusharm</a> for the contribution.
@@ -618,7 +618,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
 </ul>
 <h5>Other</h5>
 <ul>
-<li> <a href="https://github.com/gocd/gocd/issues/659">659</a> - Go has new <a href="http://www.go.cd/documentation/user/current">user documentation</a>. A big thank you to <a href="https://github.com/afoster">@afoster</a> for the commits. Thanks
+<li> <a href="https://github.com/gocd/gocd/issues/659">659</a> - Go has new <a href="https://docs.go.cd/current">user documentation</a>. A big thank you to <a href="https://github.com/afoster">@afoster</a> for the commits. Thanks
 <a href="https://github.com/gregoriomelo">@gregoriomelo</a> and <a href="https://github.com/mastojun">@mastojun</a> for your contributions. </li>
 </ul>
 </div>


### PR DESCRIPTION
* www.go.cd/documentation/user => docs.go.cd
* www.go.cd/documentation/developer => developer.go.cd/current