### PR TITLE
Added new Maven repo plugin

### DIFF
--- a/data/repo_plugins.yml
+++ b/data/repo_plugins.yml
@@ -122,3 +122,12 @@
   releases_url: https://github.com/Sounie/springer-gocd-cloudfoundry-plugin/releases/
   github_stars: http://ghbtns.com/github-btn.html?user=Sounie&repo=springer-gocd-cloudfoundry-plugin&type=watch&count=true
   first_available_date: 02/2015
+
+- name: Maven repository poller
+  description: A plugin for polling a broader range of Maven repositories.
+  readmore_url: https://github.com/1and1/go-maven-poller/blob/master/README.md
+  author_url: http://1and1.github.io/
+  author_name: 1&1 Internet SE
+  releases_url: https://github.com/1and1/go-maven-poller/releases
+  github_stars: http://ghbtns.com/github-btn.html?user=1and1&repo=go-maven-poller&type=watch&count=true
+  first_available_date: 04/2015


### PR DESCRIPTION
This plugin is build on the _Maven (Nexus) repository poller_ already listed in the plugins section. I made quite a few changes so that it is now better suited for our use cases (e.g. use of Nexus and Artifactory repositories). 