### PR TITLE
Link to changelog includes all milestone issues

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -97,7 +97,7 @@ helpers do
   end
 
   def link_to_full_changelog(text, milestone_name)
-    link_to(text, "https://github.com/gocd/gocd/pulls?q=is%3Apr+milestone%3A%22#{CGI.escape(milestone_name)}%22+is%3Amerged")
+    link_to(text, "https://github.com/gocd/gocd/issues?q=milestone%3A%22#{CGI.escape(milestone_name)}%22")
   end
 
   def value_or_default key, default_value = nil


### PR DESCRIPTION
Previously, it would only show PRs, which sometimes are less clear
than the corresponding issue.

Now all issues are shown, which includes PRs.

Please note that no filter for `is:closed` was added, as all
issues in a milestone are always closed. That way, the filter
is simpler.

Fixes #327