### PR TITLE
removed a duplicate paragraph in latest release notes

### DIFF
--- a/source/partials/release_notes/_release-16-9-0.html.erb
+++ b/source/partials/release_notes/_release-16-9-0.html.erb
@@ -106,19 +106,6 @@ and Materials</p></li>
       <li><p><%= link_to('Maven Task Plugin', 'https://github.com/ruckc/gocd-maven-plugin') %></p></li>
       <li><p><%= link_to('Publish to Artifactory', 'https://github.com/tusharm/go-artifactory-plugin') %></p></li>
     </ul>
-
-    <h5>Task plugins</h5>
-    <ul>
-      <li><p><%= link_to('MSBuild Task', 'https://github.com/akanyer/gocd-msbuild-taskplugin/blob/master/README.md') %></p></li>
-      <li><p><%= link_to('XUnit Converter', 'https://github.com/gocd-contrib/xunit-converter-task') %></p></li>
-      <li><p><%= link_to('Publish to S3', 'http://ind9.github.io/gocd-s3-artifacts') %></p></li>
-      <li><p><%= link_to('Fetch from S3', 'http://ind9.github.io/gocd-s3-artifacts') %></p></li>
-      <li><p><%= link_to('Powershell Task', 'https://github.com/manojlds/gocd-powershell-runner/blob/master/README.md') %></p></li>
-      <li><p><%= link_to('RapidDeploy Package Builder', 'https://github.com/MidVision/go-rapiddeploy/wiki#rapiddeploy-package-repository-plugin') %></p></li>
-      <li><p><%= link_to('RapidDeploy Job Runner', 'https://github.com/MidVision/go-rapiddeploy/wiki#rapiddeploy-job-runner-task-plugin') %></p></li>
-      <li><p><%= link_to('Maven Task Plugin', 'https://github.com/ruckc/gocd-maven-plugin') %></p></li>
-      <li><p><%= link_to('Publish to Artifactory', 'https://github.com/tusharm/go-artifactory-plugin') %></p></li>
-    </ul>
   </li>
 </ul>
 


### PR DESCRIPTION
Hi, the release notes seem to contain a duplicate paragraph on deprecated "Task plugins"