### PR TITLE
Update plugins which have been upgraded

### DIFF
--- a/source/partials/next_release/_release.md.erb
+++ b/source/partials/next_release/_release.md.erb
@@ -47,9 +47,6 @@ The following features have been deprecated, along with the timeframe when they 
     * [Puppet Forge repository poller](https://github.com/drrb/go-puppet-forge-poller)
     * [Debian repository poller](https://github.com/gocd-contrib/deb-repo-poller)
     * [Cloud Foundry poller](https://github.com/Sounie/springer-gocd-cloudfoundry-plugin/blob/master/README.md)
-    * [Nuget repository poller](https://github.com/ThoughtWorksInc/go-nuget-poller-plugin/)
-    * [Generic Artifactory poller](https://github.com/varchev/go-generic-artifactory-poller)
-    * [NPM repository poller](https://github.com/varchev/go-npm-poller)
 
     **Task plugins**
 

--- a/source/partials/release_notes/_release-16-12-0.md.erb
+++ b/source/partials/release_notes/_release-16-12-0.md.erb
@@ -105,9 +105,9 @@ The following features have been deprecated, along with the timeframe when they 
     * [Puppet Forge repository poller](https://github.com/drrb/go-puppet-forge-poller) [[PR submitted](https://github.com/drrb/go-puppet-forge-poller/pull/3)]
     * [Debian repository poller](https://github.com/gocd-contrib/deb-repo-poller) [[PR submitted](https://github.com/gocd-contrib/deb-repo-poller/pull/10)]
     * [Cloud Foundry poller](https://github.com/Sounie/springer-gocd-cloudfoundry-plugin/blob/master/README.md) [[PR submitted](https://github.com/Sounie/springer-gocd-cloudfoundry-plugin/pull/1)]
-    * [Nuget repository poller](https://github.com/ThoughtWorksInc/go-nuget-poller-plugin/) [[Rewritten](https://github.com/gocd-contrib/go-nuget-poller-plugin-2.0)]
-    * [Generic Artifactory poller](https://github.com/varchev/go-generic-artifactory-poller) [[PR submitted](https://github.com/varchev/go-generic-artifactory-poller/pull/14)]
-    * [NPM repository poller](https://github.com/varchev/go-npm-poller) [[PR submitted](https://github.com/varchev/go-npm-poller/pull/5)]
+    * [Nuget repository poller](https://github.com/ThoughtWorksInc/go-nuget-poller-plugin/) [[Rewritten - New release available](https://github.com/gocd-contrib/go-nuget-poller-plugin-2.0/releases)]
+    * [Generic Artifactory poller](https://github.com/varchev/go-generic-artifactory-poller) [[New release available](https://github.com/varchev/go-generic-artifactory-poller/releases)]
+    * [NPM repository poller](https://github.com/varchev/go-npm-poller) [[New release available](https://github.com/varchev/go-npm-poller/releases)]
 
     **Task plugins**
 


### PR DESCRIPTION
Removed them from the next release's release notes as well, since they should work. Should we warn that they need to be upgraded?