### PR TITLE
Add my plugin to https://www.gocd.io/plugins/

### DIFF
--- a/data/notification_plugins.yml
+++ b/data/notification_plugins.yml
@@ -87,3 +87,12 @@
   releases_url: https://github.com/gocd-contrib/gitter-activity-feed-plugin/releases
   github_stars: http://ghbtns.com/github-btn.html?user=gocd-contrib&repo=gitter-activity-feed-plugin&type=watch&count=true
   first_available_date: 11/2016
+
+- name: Build-Watcher Notification
+  description: Plugin that sends direct emails and Slack messages to the person who breaks a build
+  readmore_url: https://github.com/gmazzo/gocd-build-watcher-plugin
+  author_url: https://github.com/gmazzo
+  author_name: Guillermo Mazzola
+  releases_url: https://bintray.com/gmazzo/maven/gocd-build-watcher-plugin/_latestVersion
+  github_stars: http://ghbtns.com/github-btn.html?user=gmazzo&repo=gocd-build-watcher-plugin&type=watch&count=true
+  first_available_date: 04/2017


### PR DESCRIPTION
Hello, I've made the following plugin, can you add it to the GoCD's plugins page?
https://github.com/gmazzo/gocd-build-watcher-plugin

Regards