### PR TITLE
Improvements to the new downloads page

### DIFF
--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -146,15 +146,7 @@ var determinePackageNameBasedOnOS = function () {
 var newHighlightSelectedOs = (function ($) {
   return function () {
     $(".download-nav li span").click(function () {
-      $(".tab_content").hide();
-      var activeTab = $(this).attr("rel");
-      $(activeTab).fadeIn();
-      $(".download-nav li span").removeClass("active");
-      $(this).addClass("active");
-
-      $(".tab-accordion_heading").removeClass("d_active");
-      $(".tab-accordion_heading[rel^='" + activeTab + "']").addClass("d_active");
-
+      switchActiveTab(this, ".download-nav li span", ".tab-accordion_heading")
     });
   }
 })(jQuery);

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -9,14 +9,16 @@ var newShowDownloadLinks = (function ($) {
         download_prefix: 'https://download.gocd.org/binaries/',
         version_to_show: function (release) {
           return release['go_version'];
-        }
+        },
+        cloud_info_url: 'https://download.gocd.org/cloud.json'
       },
       experimental: {
         download_info_url: 'https://download.gocd.org/experimental/releases.json',
         download_prefix: 'https://download.gocd.org/experimental/binaries/',
         version_to_show: function (release) {
           return release['go_full_version'];
-        }
+        },
+        cloud_info_url: 'https://download.gocd.org/cloud.json'
       }
     };
 
@@ -74,10 +76,10 @@ var newShowDownloadLinks = (function ($) {
       return segmentsA.length - segmentsB.length;
     }
 
-    var showReleases = function (data1, data2) {
-      var releases = R.compose(releasesLessThanAYearOld, R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(data1[0]);
+    var showReleases = function (releaseData, amiData) {
+      var releases = R.compose(releasesLessThanAYearOld, R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
       if (typeOfInstallersToShow == 'stable') {
-        var amiReleases = R.sortBy(R.prop('go_version'))(data2[0]).reverse();
+        var amiReleases = R.sortBy(R.prop('go_version'))(amiData[0]).reverse();
         var latest_cloud_release = R.head(amiReleases);
         var other_cloud_releases = R.tail(amiReleases);
       }
@@ -98,7 +100,7 @@ var newShowDownloadLinks = (function ($) {
       console.log("Error: " + error);
     };
 
-    return $.when($.getJSON(settings.download_info_url), $.getJSON('https://download.gocd.org/cloud.json'))
+    return $.when($.getJSON(settings.download_info_url), $.getJSON(settings.cloud_info_url))
       .done(showReleases)
       .fail(showFailureMessage);
   };

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -169,5 +169,19 @@ var newHighlightSelectedOs = (function ($) {
   }
 })(jQuery);
 
+var showHelpLinksFor = (function ($) {
+  return function(packageName) {
+    var installer_type_to_help_link_type = {
+      'debian': 'linux',
+      'redhat': 'linux',
+      'windows': 'windows',
+      'zip': 'zip',
+      'osx': 'osx'
+    };
+    var template = Handlebars.compile($("#downloads-help-links").html());
 
-
+    $("#help-links").html(template({
+      os: installer_type_to_help_link_type[packageName]
+    }));
+  };
+})(jQuery);

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -49,27 +49,29 @@ var newShowDownloadLinks = (function ($) {
       return R.assoc('display_version', settings.version_to_show(release), release);
     });
 
-    function compareVersions(a, b) {
-      var i, diff;
+    var compareVersions = function(propertyToCompareOn) {
+      return function (a, b) {
+        var i, diff;
 
-      var segmentsA = a.go_full_version.replace('-', '.').split('.');
-      var segmentsB = b.go_full_version.replace('-', '.').split('.');
+        var segmentsA = a[propertyToCompareOn].replace('-', '.').split('.');
+        var segmentsB = b[propertyToCompareOn].replace('-', '.').split('.');
 
-      var l = Math.min(segmentsA.length, segmentsB.length);
+        var l = Math.min(segmentsA.length, segmentsB.length);
 
-      for (i = 0; i < l; i++) {
-        diff = parseInt(segmentsB[i], 10) - parseInt(segmentsA[i], 10);
-        if (diff) {
-          return diff;
+        for (i = 0; i < l; i++) {
+          diff = parseInt(segmentsB[i], 10) - parseInt(segmentsA[i], 10);
+          if (diff) {
+            return diff;
+          }
         }
+        return segmentsA.length - segmentsB.length;
       }
-      return segmentsA.length - segmentsB.length;
-    }
+    };
 
     var showReleases = function (releaseData, amiData) {
-      var releases = R.compose(R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
+      var releases = R.compose(R.sort(compareVersions('go_full_version')), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
       if (typeOfInstallersToShow === 'stable') {
-        var amiReleases = R.sortBy(R.prop('go_version'))(amiData[0]).reverse();
+        var amiReleases = R.sort(compareVersions('go_version'))(amiData[0]);
         var latest_cloud_release = R.head(amiReleases);
         var other_cloud_releases = R.tail(amiReleases);
       }

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -91,6 +91,8 @@ var newShowDownloadLinks = (function ($) {
       console.log("Error: " + error);
     };
 
+    $("#downloads").html($(".loading-message-template").html());
+
     return $.when(downloadOrGetFromCache(settings.download_info_url), downloadOrGetFromCache(settings.cloud_info_url))
       .done(showReleases)
       .fail(showFailureMessage);

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -1,7 +1,6 @@
 var newShowDownloadLinks = (function ($) {
   return function (options) {
     var typeOfInstallersToShow = options.typeOfInstallersToShow;
-    var showArchive = options.archive;
 
     var settingsForAllTypes = {
       stable: {
@@ -23,15 +22,6 @@ var newShowDownloadLinks = (function ($) {
     };
 
     var settings = settingsForAllTypes[typeOfInstallersToShow];
-
-    var dateFilter = R.curry(function (timeInSecondsSinceEpoch) {
-      if (showArchive) {
-        return true;
-      }
-      return (new Date() - new Date(timeInSecondsSinceEpoch * 1000)) < 3600 * 24 * 366 * 1000;
-    });
-
-    var releasesLessThanAYearOld = R.filter(R.where({release_time: dateFilter}));
 
     var addURLToFiles = function (release) {
       var addDetailsFrom = R.curry(function (release, analyticsIDPrefix, o) {
@@ -77,7 +67,7 @@ var newShowDownloadLinks = (function ($) {
     }
 
     var showReleases = function (releaseData, amiData) {
-      var releases = R.compose(releasesLessThanAYearOld, R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
+      var releases = R.compose(R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
       if (typeOfInstallersToShow === 'stable') {
         var amiReleases = R.sortBy(R.prop('go_version'))(amiData[0]).reverse();
         var latest_cloud_release = R.head(amiReleases);

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -115,7 +115,7 @@ var downloadOrGetFromCache = (function($) {
 
 var newSetupShowVerifyChecksumMessage = (function ($) {
   return function () {
-    $("#downloads").on('click', '.verify-checksum', function (evt) {
+    $("body").on('click', '#downloads .verify-checksum', function (evt) {
       var checksumElement = $(evt.currentTarget);
       var template = Handlebars.compile($("#verify-checksum-message-template").html());
       $("#verify-checksum-message").html(template({
@@ -142,14 +142,6 @@ var determinePackageNameBasedOnOS = function () {
 
   return packageName
 };
-
-var newHighlightSelectedOs = (function ($) {
-  return function () {
-    $(".download-nav li span").click(function () {
-      switchActiveTab(this, ".download-nav li span", ".tab-accordion_heading")
-    });
-  }
-})(jQuery);
 
 var showHelpLinksFor = (function ($) {
   return function(packageName) {

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -100,9 +100,26 @@ var newShowDownloadLinks = (function ($) {
       console.log("Error: " + error);
     };
 
-    return $.when($.getJSON(settings.download_info_url), $.getJSON(settings.cloud_info_url))
+    return $.when(downloadOrGetFromCache(settings.download_info_url), downloadOrGetFromCache(settings.cloud_info_url))
       .done(showReleases)
       .fail(showFailureMessage);
+  };
+})(jQuery);
+
+var downloadOrGetFromCache = (function($) {
+  var storedJSON = {};
+
+  return function (url) {
+    var deferred = $.Deferred();
+
+    if (storedJSON.hasOwnProperty(url)) {
+      deferred.resolve([storedJSON[url], "success"]);
+      return deferred.promise();
+    }
+
+    return $.getJSON(url).done(function (data) {
+      storedJSON[url] = data;
+    });
   };
 })(jQuery);
 

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -78,7 +78,7 @@ var newShowDownloadLinks = (function ($) {
 
     var showReleases = function (releaseData, amiData) {
       var releases = R.compose(releasesLessThanAYearOld, R.sort(compareVersions), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
-      if (typeOfInstallersToShow == 'stable') {
+      if (typeOfInstallersToShow === 'stable') {
         var amiReleases = R.sortBy(R.prop('go_version'))(amiData[0]).reverse();
         var latest_cloud_release = R.head(amiReleases);
         var other_cloud_releases = R.tail(amiReleases);

--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -82,7 +82,6 @@ var newShowDownloadLinks = (function ($) {
         latest_version: releases[0].go_version,
         latest_cloud_release: latest_cloud_release,
         all_other_cloud_releases: other_cloud_releases
-
       }));
     };
 

--- a/source/assets/javascripts/app/_tabs.js
+++ b/source/assets/javascripts/app/_tabs.js
@@ -18,34 +18,31 @@ var startTabContainer = function ($, packageName) {
 
   $(".tab_content").hide();
   $(".tab_content:first").show();
+  $("ul.tabs li:first").addClass("active");
   $("span[rel=\"" + package_to_rel[packageName] + "\"]").addClass("active");
   $(".tab-accordion_heading[rel^='" + package_to_os[packageName] + "']").addClass("d_active");
   chooseTabContainer($);
 };
 
-var chooseTabContainer = function ($) {
-  $("ul.tabs li , ul.items li").click(function () {
-    $(".tab_content").hide();
-    var activeTab = $(this).attr("rel");
-    $("#" + activeTab).fadeIn();
-    $("ul.tabs li").removeClass("active");
-    $(this).addClass("active");
+var switchActiveTab = function (newElementWhichShouldBeActive, selectorForAllElementsOfThisType, selectorForOtherKindOfTab) {
+  $(".tab_content").hide();
+  var activeTab = $(newElementWhichShouldBeActive).attr("rel");
+  $("#" + activeTab).fadeIn();
 
-    $(".tab-accordion_heading").removeClass("d_active");
-    $(".tab-accordion_heading[rel^='" + activeTab + "']").addClass("d_active");
+  $(selectorForAllElementsOfThisType).removeClass("active");
+  $(newElementWhichShouldBeActive).addClass("active");
+
+  $(selectorForOtherKindOfTab).removeClass("d_active");
+  $(selectorForOtherKindOfTab + "[rel^='" + activeTab + "']").addClass("d_active");
+};
+
+var chooseTabContainer = function ($) {
+  $("ul.tabs li").click(function () {
+    switchActiveTab(this, "ul.tabs li", ".tab-accordion_heading");
   });
 
-  /* accordion mode */
   $(".tab-accordion_heading").click(function () {
-    $(".tab_content").hide();
-    var d_activeTab = $(this).attr("rel");
-    $("#" + d_activeTab).fadeIn();
-
-    $(".tab-accordion_heading").removeClass("d_active");
-    $(this).addClass("d_active");
-
-    $("ul.tabs li").removeClass("active");
-    $("ul.tabs li[rel^='" + d_activeTab + "']").addClass("active");
+    switchActiveTab(this, ".tab-accordion_heading", "ul.tabs li");
   });
 
   if (window.location.hash) {

--- a/source/assets/javascripts/app/_tabs.js
+++ b/source/assets/javascripts/app/_tabs.js
@@ -1,52 +1,21 @@
-//horizontal tabs
-var startTabContainer = function ($, packageName) {
-  var package_to_rel = {
-    "debian": "tab-debian",
-    'redhat': 'tab-redhat',
-    "windows": "tab-windows",
-    'zip': 'tab-zip',
-    'osx': 'tab-osx'
-  };
-
-  var package_to_os = {
-    "debian": "deb",
-    'redhat': 'rpm',
-    "windows": "win",
-    'zip': 'generic',
-    'osx': 'osx'
-  };
-
+var startTabContainer = function ($) {
   $(".tab_content").hide();
   $(".tab_content:first").show();
-  $("ul.tabs li:first").addClass("active");
-  $("span[rel=\"" + package_to_rel[packageName] + "\"]").addClass("active");
-  $(".tab-accordion_heading[rel^='" + package_to_os[packageName] + "']").addClass("d_active");
-  chooseTabContainer($);
-};
+  $(".tab-container-marker .tab-marker:first").addClass("active").addClass("d_active");
 
-var switchActiveTab = function (newElementWhichShouldBeActive, selectorForAllElementsOfThisType, selectorForOtherKindOfTab) {
-  $(".tab_content").hide();
-  var activeTab = $(newElementWhichShouldBeActive).attr("rel");
-  $("#" + activeTab).fadeIn();
-
-  $(selectorForAllElementsOfThisType).removeClass("active");
-  $(newElementWhichShouldBeActive).addClass("active");
-
-  $(selectorForOtherKindOfTab).removeClass("d_active");
-  $(selectorForOtherKindOfTab + "[rel^='" + activeTab + "']").addClass("d_active");
-};
-
-var chooseTabContainer = function ($) {
-  $("ul.tabs li").click(function () {
-    switchActiveTab(this, "ul.tabs li", ".tab-accordion_heading");
-  });
-
-  $(".tab-accordion_heading").click(function () {
-    switchActiveTab(this, ".tab-accordion_heading", "ul.tabs li");
+  $("body").on('click', '.tab-container-marker .tab-marker', function () {
+    switchActiveTab($(this).attr('rel'));
   });
 
   if (window.location.hash) {
-    release = window.location.hash.substring(1).replace(/\./g, '-');
-    $('[rel=' + release + ']').click();
+    switchActiveTab(window.location.hash.substring(1).replace(/\./g, '-'));
   }
+};
+
+var switchActiveTab = function (tabIdentifier) {
+  $(".tab_content").hide();
+  $(".tab_content#" + tabIdentifier).fadeIn();
+
+  $(".tab-container-marker .tab-marker").removeClass("active").removeClass("d_active");
+  $(".tab-container-marker .tab-marker[rel='" + tabIdentifier + "']").addClass("active").addClass("d_active");
 };

--- a/source/assets/javascripts/app/_tabs.js
+++ b/source/assets/javascripts/app/_tabs.js
@@ -1,16 +1,18 @@
-var startTabContainer = function ($) {
-  $(".tab_content").hide();
-  $(".tab_content:first").show();
-  $(".tab-container-marker .tab-marker:first").addClass("active").addClass("d_active");
+var startTabContainer = (function ($) {
+  return function () {
+    $(".tab_content").hide();
+    $(".tab_content:first").show();
+    $(".tab-container-marker .tab-marker:first").addClass("active").addClass("d_active");
 
-  $("body").on('click', '.tab-container-marker .tab-marker', function () {
-    switchActiveTab($(this).attr('rel'));
-  });
+    $("body").on('click', '.tab-container-marker .tab-marker', function () {
+      switchActiveTab($(this).attr('rel'));
+    });
 
-  if (window.location.hash) {
-    switchActiveTab(window.location.hash.substring(1).replace(/\./g, '-'));
-  }
-};
+    if (window.location.hash) {
+      switchActiveTab(window.location.hash.substring(1).replace(/\./g, '-'));
+    }
+  };
+})(jQuery);
 
 var switchActiveTab = function (tabIdentifier) {
   $(".tab_content").hide();

--- a/source/assets/javascripts/app/_tabs.js
+++ b/source/assets/javascripts/app/_tabs.js
@@ -1,3 +1,19 @@
+/*
+ Expects something like the snippet below. Only the class names and IDs are important. Not the tags:
+
+ <ul class="tab-container-marker">
+   <li><span class="tab-marker" rel="tab-id-1">Tab 1</li>
+   <li><span class="tab-marker" rel="tab-id-2">Tab 2</li>
+ </ul>
+
+ <div>
+   <div id="tab-id-1" class="tab_content">
+   </div>
+   <div id="tab-id-2" class="tab_content">
+   </div>
+ </div>
+ */
+
 var startTabContainer = (function ($) {
   return function () {
     $(".tab_content").hide();

--- a/source/assets/stylesheets/scss/_downloads_new.scss
+++ b/source/assets/stylesheets/scss/_downloads_new.scss
@@ -62,6 +62,10 @@ body.download_new {
     position: relative;
     padding-top: 20px;
 
+    .file-not-available {
+      text-align: center;
+    }
+
     .file {
       float: left;
       margin-bottom: 10px;

--- a/source/assets/stylesheets/scss/_downloads_new.scss
+++ b/source/assets/stylesheets/scss/_downloads_new.scss
@@ -1,4 +1,8 @@
 body.download_new {
+  .go {
+    text-transform: none;
+  }
+
   .download-area {
     .info {
       text-align: center;
@@ -209,6 +213,7 @@ body.download_new {
         font-size: 16px;
         text-transform: uppercase;
         margin-bottom: 0;
+        font-weight: 400;
       }
       .small {
         font-size: 12px;
@@ -370,7 +375,7 @@ body.download_new {
     }
 
     .btn-release {
-      border-radius: 10px;
+      border-radius: 3px;
       background: #fff;
       border: 1px solid $border;
       font-size: 12px;
@@ -484,18 +489,18 @@ body.download_new {
     overflow: hidden;
 
     .btn-primary {
-      color: $primary-color;
-      background-color: #ffffff;
+      color: #fff;
+      background-color: $primary-color;
       border-color: $primary-color;
       transition: all 0.2s ease-in-out;
 
       &:hover {
-        background: $primary-color;
-        color: #fff;
+        background: #fff;
+        color: $primary-color;
         transition: all 0.2s ease-in-out;
 
         span {
-          color: #fff;
+          color: $primary-color;
 
           &.bit {
             color: #000;

--- a/source/cloud.html.erb
+++ b/source/cloud.html.erb
@@ -16,14 +16,14 @@ title_tag_of_header: "AMIs for GoCD"
     <h3 class="subcaption">Amazon Linux based image for <b>GoCD Server</b></h3>
     <h5 class="subcaption">Please log your feedback or issues on <a href="https://github.com/gocd/gocd-cloud">github</a> for the following</h5>
     <div class="v-tabs all-releases">
-      <ul class="tabs">
+      <ul class="tabs tab-container-marker">
         <%  data.amis.keys.reverse.collect(&:to_s).each_with_index do |release, index| %>
-            <li rel="tab-<%= release.gsub('.', '-') %>"<%= ' class="active"' if index == 0 %>><%= release %><%= ' (latest)' if index == 0 %></li>
+            <li rel="tab-<%= release.gsub('.', '-') %>" class="tab-marker<%= index == 0 ? ' active' : '' %>"><%= release %><%= ' (latest)' if index == 0 %></li>
         <% end %>
       </ul>
-      <div class="tab_container">
+      <div class="tab_container tab-container-marker">
         <%  data.amis.keys.sort.reverse.collect(&:to_s).each_with_index do |release, index| %>
-            <h3 class="tab-accordion_heading<%= ' d_active' if index == 0 %>" rel="tab-<%= release.gsub('.', '-')%>"><%= release %><%= ' (latest)' if index == 0 %></h3>
+            <h3 class="tab-marker tab-accordion_heading<%= ' d_active' if index == 0 %>" rel="tab-<%= release.gsub('.', '-')%>"><%= release %><%= ' (latest)' if index == 0 %></h3>
             <div id="tab-<%= release.gsub('.', '-')%>" class="tab_content" style="display: block;">
               <div class="content amis">
                 <h2>Demo AMI</h2>

--- a/source/cloud.html.erb
+++ b/source/cloud.html.erb
@@ -42,6 +42,6 @@ title_tag_of_header: "AMIs for GoCD"
 </main>
 <script>
     jQuery(document).ready(function ($) {
-        startTabContainer($);
+        startTabContainer();
     });
 </script>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -151,7 +151,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 {{/inline}}
 
 {{#*inline "show-tab-header"}}
-<li rel="{{{tab_id}}}">
+<li class="tab-marker" rel="{{{tab_id}}}">
   <span class="os-logo"><img src="{{{image}}}" alt="{{{desc}}}" /></span>
   <span class="desc">{{{desc}}}</span>
 </li>
@@ -177,7 +177,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   <div class="container">
     <h2 class="sub-title">Choose your OS &amp; download</h2>
     <p class="info">Latest supported release (<span id="latest-version">{{latest_version}}</span>) <a href="../releases/#latest" class="btn btn-dark">See what's new</a> </p>
-    <ul class="tabs os">
+    <ul class="tabs os tab-container-marker">
       {{> show-tab-header tab_id="tab-windows" image="<%= image_path "download/windows.png" %>" desc="Windows"}}
       {{> show-tab-header tab_id="tab-osx" image="<%= image_path "download/osx.png" %>" desc="OSX"}}
       {{> show-tab-header tab_id="tab-debian" image="<%= image_path "download/debian.png" %>" desc="Debian"}}
@@ -188,16 +188,16 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 </div>
 <div class="os-tab-content">
   <div class="container">
-    <div class="tab_container">
-      <h3 class="tab-accordion_heading" rel="tab-windows">Windows</h3>
+    <div class="tab_container tab-container-marker">
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-windows">Windows</h3>
       {{> show-releases-for-installer-type installer_type="win"     heading="Windows" tab_id="tab-windows"}}
-      <h3 class="tab-accordion_heading" rel="tab-osx">OSX</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-osx">OSX</h3>
       {{> show-releases-for-installer-type installer_type="osx"     heading="OSX"     tab_id="tab-osx"}}
-      <h3 class="tab-accordion_heading" rel="tab-debian">Debian</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-debian">Debian</h3>
       {{> show-releases-for-installer-type installer_type="deb"     heading="Debian"  tab_id="tab-debian"}}
-      <h3 class="tab-accordion_heading" rel="tab-redhat">RPM</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-redhat">RPM</h3>
       {{> show-releases-for-installer-type installer_type="rpm"     heading="RPM"     tab_id="tab-redhat"}}
-      <h3 class="tab-accordion_heading" rel="tab-zip">Zip</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-zip">Zip</h3>
       {{> show-releases-for-installer-type installer_type="generic" heading="Zip" tab_id="tab-zip"}}
     </div>
   </div>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -211,7 +211,7 @@ jQuery(document).ready(function($) {
   var isExperimental = R.any(R.equals('experimental=true'), window.location.search.substr(1).split('&'));
   showDownloadLinks({ typeOfInstallersToShow: isExperimental ? "experimental" : "stable"})
     .then(function() {
-      startTabContainer($);
+      startTabContainer();
     }).then(function(){
       var package="zip";
       var appVersion = navigator.appVersion;

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -363,33 +363,33 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 <script>
   // <![CDATA[
   jQuery(document).ready(function ($) {
-    var typeOfInstallersToShow = "stable";
-    var packageName = determinePackageNameBasedOnOS();
+    var currentInstallerType = "stable";
+    var currentOSPackageType = determinePackageNameBasedOnOS();
 
     /* Switch OSes. */
     $(".download-nav li [rel^='tab-']").on('click', function () {
-      packageName = $(this).attr('rel').replace('tab-', '');
-      showHelpLinksFor(packageName);
+      currentOSPackageType = $(this).attr('rel').replace('tab-', '');
+      showHelpLinksFor(currentOSPackageType);
     });
 
     /* Switch between stable and experimental. */
     $('input[type=radio][name=typeOfDownloads]').on('change', function () {
-      typeOfInstallersToShow = $(this).val();
-      newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
+      currentInstallerType = $(this).val();
+      newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
         .done(function () {
           chooseTabContainer($);
         })
         .done(function () {
-          $('[rel=tab-' + packageName + ']').click();
+          $('[rel=tab-' + currentOSPackageType + ']').click();
         });
     });
 
-    newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
+    newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
       .done(function () {
-        startTabContainer($, packageName);
+        startTabContainer($, currentOSPackageType);
       })
       .done(function () {
-        $('[rel=tab-' + packageName + ']').click();
+        $('[rel=tab-' + currentOSPackageType + ']').click();
       });
 
     newSetupShowVerifyChecksumMessage();

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -7,7 +7,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 <div class="inner-banner plugins">
   <div class="container">
     <div class="banner-content">
-      <h1 class="caption"><span>Download</span></h1>
+      <h1 class="caption"><span>Download <span class="go">Go</span>CD now</span></h1>
     </div>
   </div>
 </div>

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -367,33 +367,29 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     var currentOSPackageType = determinePackageNameBasedOnOS();
 
     /* Switch OSes. */
-    $(".download-nav li [rel^='tab-']").on('click', function () {
+    $("body").on('click', '.tab-container-marker .tab-marker', function () {
       currentOSPackageType = $(this).attr('rel').replace('tab-', '');
+
       showHelpLinksFor(currentOSPackageType);
     });
 
     /* Switch between stable and experimental. */
     $('input[type=radio][name=typeOfDownloads]').on('change', function () {
       currentInstallerType = $(this).val();
+
       newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
         .done(function () {
-          chooseTabContainer($);
-        })
-        .done(function () {
-          $('[rel=tab-' + currentOSPackageType + ']').click();
+          switchActiveTab('tab-' + currentOSPackageType);
         });
     });
 
     newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
       .done(function () {
-        startTabContainer($, currentOSPackageType);
-      })
-      .done(function () {
-        $('[rel=tab-' + currentOSPackageType + ']').click();
+        startTabContainer($);
+        switchActiveTab('tab-' + currentOSPackageType);
       });
 
     newSetupShowVerifyChecksumMessage();
-    newHighlightSelectedOs();
   });
   // ]]>
 </script>

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -79,8 +79,6 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
           <label for="stable">Stable</label>
           <input type="radio" id="experimental" name="typeOfDownloads" value="experimental" />
           <label for="experimental">Experimental</label>
-          <input type="radio" id="archive" name="typeOfDownloads" value="archive" />
-          <label for="archive">Archived</label>
         </div>
         <div id="downloads">
           <div class="load-message">
@@ -366,7 +364,6 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   // <![CDATA[
   jQuery(document).ready(function ($) {
     var typeOfInstallersToShow = "stable";
-    var archive = false;
     var packageName = determinePackageNameBasedOnOS();
 
     /* Switch OSes. */
@@ -378,14 +375,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     /* Switch between stable and experimental. */
     $('input[type=radio][name=typeOfDownloads]').on('change', function () {
       typeOfInstallersToShow = $(this).val();
-      if (typeOfInstallersToShow === "archive") {
-        archive = true;
-        typeOfInstallersToShow = "stable";
-      }
-      else {
-        archive = false;
-      }
-      newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow, archive: archive})
+      newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
         .done(function () {
           chooseTabContainer($);
         })

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -1,7 +1,7 @@
 ---
 title: GoCD - Download
 title_tag_of_header: "Download for Free - Server and Agent | GoCD"
-meta_description: "Download GoCD's open source continuous delivery server for OS for free. Community and commercial support available."
+meta_description: "Download GoCD - open source continuous delivery server - for free. Community and commercial support available."
 meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 ---
 <div class="inner-banner plugins">
@@ -369,13 +369,6 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     var archive = false;
     var packageName = determinePackageNameBasedOnOS();
 
-    newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
-      .then(function () {
-        startTabContainer($, packageName);
-      }).then(function () {
-      $('[rel=tab-' + packageName + ']').click();
-    });
-
     $('input[type=radio][name=typeOfDownloads]').on('change', function () {
       typeOfInstallersToShow = $(this).val();
       if (typeOfInstallersToShow === "archive") {
@@ -388,26 +381,25 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
       newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow, archive: archive})
         .then(function () {
           chooseTabContainer($);
-        }).then(function () {
+        })
+        .then(function () {
+          $('[rel=tab-' + packageName + ']').click();
+        });
+    });
+
+    $(".download-nav li").on('click', function () {
+      packageName = $(this).find('.active').attr('rel').replace('tab-', '');
+      showHelpLinksFor(packageName);
+    });
+
+    newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
+      .then(function () {
+        startTabContainer($, packageName);
+      })
+      .then(function () {
         $('[rel=tab-' + packageName + ']').click();
       });
-    });
-    $(".download-nav li").on('click', function () {
-      var type_of_os = {
-        "tab-debian": "linux",
-        'tab-redhat': 'linux',
-        "tab-windows": "windows",
-        'tab-zip': 'zip',
-        'tab-osx': 'osx'
-      };
-      var template = Handlebars.compile($("#downloads-help-links").html());
-      var type = $(this).find('.active').attr('rel');
-      packageName = type.split('-')[1];
 
-      $("#help-links").html(template({
-        os: type_of_os[type]
-      }));
-    });
     newSetupShowVerifyChecksumMessage();
     newHighlightSelectedOs();
   });

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -369,6 +369,13 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     var archive = false;
     var packageName = determinePackageNameBasedOnOS();
 
+    /* Switch OSes. */
+    $(".download-nav li [rel^='tab-']").on('click', function () {
+      packageName = $(this).attr('rel').replace('tab-', '');
+      showHelpLinksFor(packageName);
+    });
+
+    /* Switch between stable and experimental. */
     $('input[type=radio][name=typeOfDownloads]').on('change', function () {
       typeOfInstallersToShow = $(this).val();
       if (typeOfInstallersToShow === "archive") {
@@ -379,24 +386,19 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
         archive = false;
       }
       newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow, archive: archive})
-        .then(function () {
+        .done(function () {
           chooseTabContainer($);
         })
-        .then(function () {
+        .done(function () {
           $('[rel=tab-' + packageName + ']').click();
         });
     });
 
-    $(".download-nav li").on('click', function () {
-      packageName = $(this).find('.active').attr('rel').replace('tab-', '');
-      showHelpLinksFor(packageName);
-    });
-
     newShowDownloadLinks({typeOfInstallersToShow: typeOfInstallersToShow})
-      .then(function () {
+      .done(function () {
         startTabContainer($, packageName);
       })
-      .then(function () {
+      .done(function () {
         $('[rel=tab-' + packageName + ']').click();
       });
 

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -80,12 +80,15 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
           <input type="radio" id="experimental" name="typeOfDownloads" value="experimental" />
           <label for="experimental">Experimental</label>
         </div>
-        <div id="downloads">
+
+        <div class="loading-message-template" style="display: none">
           <div class="load-message">
             <i class="fa fa-spinner fa-spin fa-5x" aria-hidden="true"></i>
-            <span> Please wait. Fetching information about download ...</span>
+            <span>Please wait. Fetching information about available packages ...</span>
           </div>
         </div>
+
+        <div id="downloads"></div>
       </div>
       <div class="col-sm-4 col-lg-3 col-md-3">
         <ul class="help-links" id="help-links">

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -163,18 +163,21 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
         <div class="col-xs-12 col-sm-4 col-lg-3 col-lg-3 ">
           <span class="version">{{display_version}}</span>
         </div>
+        {{#if (lookup . ../installer_type)}}
         {{#with (lookup . ../installer_type)}}
         <div class="col-xs-12 col-sm-8 col-lg-9 ">
           <div class="files">
             {{#if server32bit}}
             {{> show-server-and-agent-32-and-64-bit-installers}}
-          
             {{else}}
             {{> show-server-and-agent-installer}}
             {{/if}}
           </div>
         </div>
         {{/with}}
+        {{else}}
+        <div class="files"><div class="file-not-available">Not available</div></div>
+        {{/if}}
       </div>
       {{/each}}
     </div>

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -18,22 +18,22 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
         <button class="download-btn"><i class="fa fa-bars"></i></button>
 
         <nav class="sidebar-nav download-nav">
-          <ul class="verticalnav">
+          <ul class="verticalnav tab-container-marker">
             <li class="dropdown open">
               <span class="head">OS Types</span>
               <ul>
-                <li><span rel="tab-redhat">RPM/YUM</span></li>
-                <li><span rel="tab-debian"> Debian/APT</span></li>
-                <li><span rel="tab-zip">Zip</span></li>
-                <li><span rel="tab-windows">Windows</span></li>
-                <li><span rel="tab-osx">OSX</span></li>
+                <li><span class="tab-marker" rel="tab-redhat">RPM/YUM</span></li>
+                <li><span class="tab-marker" rel="tab-debian"> Debian/APT</span></li>
+                <li><span class="tab-marker" rel="tab-zip">Zip</span></li>
+                <li><span class="tab-marker" rel="tab-windows">Windows</span></li>
+                <li><span class="tab-marker" rel="tab-osx">OSX</span></li>
               </ul>
             </li>
             <li class="dropdown open">
               <span class="head">Cloud Providers</span>
               <ul>
-                <li><span rel="tab-ami">Amazon AMI</span></li>
-                <li><span rel="tab-docker">Docker</span></li>
+                <li><span class="tab-marker" rel="tab-ami">Amazon AMI</span></li>
+                <li><span class="tab-marker" rel="tab-docker">Docker</span></li>
               </ul>
             </li>
           </ul>
@@ -341,20 +341,20 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   <div class="download-area">
   </div>
   <div class="os-tab-content">
-    <div class="tab_container">
-      <h3 class="tab-accordion_heading" rel="tab-windows">Windows</h3>
+    <div class="tab_container tab-container-marker">
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-windows">Windows</h3>
       {{> show-releases-for-installer-type installer_type="win" heading="Windows" tab_id="tab-windows"}}
-      <h3 class="tab-accordion_heading" rel="tab-osx">OSX</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-osx">OSX</h3>
       {{> show-releases-for-installer-type installer_type="osx" heading="OSX" tab_id="tab-osx"}}
-      <h3 class="tab-accordion_heading" rel="tab-debian">Debian</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-debian">Debian</h3>
       {{> show-releases-for-installer-type installer_type="deb" heading="Debian" tab_id="tab-debian"}}
-      <h3 class="tab-accordion_heading" rel="tab-redhat">RPM</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-redhat">RPM</h3>
       {{> show-releases-for-installer-type installer_type="rpm" heading="RPM" tab_id="tab-redhat"}}
-      <h3 class="tab-accordion_heading" rel="tab-zip">Zip</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-zip">Zip</h3>
       {{> show-releases-for-installer-type installer_type="generic" heading="Zip" tab_id="tab-zip"}}
-      <h3 class="tab-accordion_heading" rel="tab-ami">AMIs</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-ami">AMIs</h3>
       {{> show-amis installer_type="ami" tab_id="tab-ami"}}
-      <h3 class="tab-accordion_heading" rel="tab-docker">Docker</h3>
+      <h3 class="tab-marker tab-accordion_heading" rel="tab-docker">Docker</h3>
       {{> show-docker installer_type="docker" tab_id="tab-docker"}}
     </div>
     <div id="verify-checksum-message"></div>

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -385,7 +385,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 
     newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
       .done(function () {
-        startTabContainer($);
+        startTabContainer();
         switchActiveTab('tab-' + currentOSPackageType);
       });
 

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -96,7 +96,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
           <li><a href="https://docs.gocd.org/current/installation/install/agent/linux.html"  target="_blank">Agent Installation
             Instructions</a></li>
         </ul>
-        <p>If you need help downloading, installing or using GoCD please join the <a href="https://groups.google.com/forum/#!forum/go-cd">GoCD Users Google Group</a>.</p>
+        <p>If you need help downloading, installing or using GoCD please join the <a href="https://groups.google.com/forum/#!forum/go-cd" target="_blank">GoCD Users Google Group</a>.</p>
         <div class='subscribe-to-blog blogpost'>
           <h3 class='subscribe-title'> Subscribe for updates on new GoCD releases</h3>
           <script src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>

--- a/source/next-release.html.erb
+++ b/source/next-release.html.erb
@@ -37,6 +37,6 @@ title_tag_of_header: "Next release of GoCD"
 </main>
 <script>
 jQuery(document).ready(function($) {
-  startTabContainer($);
+  startTabContainer();
 });
 </script>

--- a/source/next-release.html.erb
+++ b/source/next-release.html.erb
@@ -19,12 +19,12 @@ title_tag_of_header: "Next release of GoCD"
   </p>
 
   <div class="v-tabs all-releases">
-    <ul class="tabs">
-      <li rel="tab-next" class="active"> (latest)</li>
+    <ul class="tabs tab-container-marker">
+      <li rel="tab-next tab-marker" class="active"> (latest)</li>
     </ul>
 
-    <div class="tab_container">
-      <h3 class="tab-accordion_heading d_active" rel="tab-next"> (next)</h3>
+    <div class="tab_container tab-container-marker">
+      <h3 class="tab-marker tab-accordion_heading d_active" rel="tab-next"> (next)</h3>
       <div id="tab-next" class="tab_content" style="display: block;">
         <div class="content">
           <%= partial "partials/next_release/release" %>

--- a/source/plugins.html.erb
+++ b/source/plugins.html.erb
@@ -55,18 +55,18 @@ meta_keywords: "GoCD, continuous delivery, software, continuous integration, ope
       {kind: "Commercial Offerings", plugins: data.paid_plugins}
     ] %>
     <div class="v-tabs all-plugins">
-      <ul class="tabs">
+      <ul class="tabs tab-container-marker">
         <% plugin_categories.each_with_index do |category, index| %>
-          <li rel="tab-<%= index + 1 %>" id="<%= category[:kind].downcase.gsub(' ','-')%>">
+          <li class="tab-marker" rel="tab-<%= index + 1 %>" id="<%= category[:kind].downcase.gsub(' ','-')%>">
             <%= category[:kind] %> <% if category[:version_info] %><span class="plugin-info"><%= category[:version_info] %></span><% end %>
           </li>
         <% end %>
       </ul>
 
-      <div class="tab_container">
+      <div class="tab_container tab-container-marker">
         <% plugin_categories.each_with_index do |category, index| %>
           <% tab_id = "tab-#{index + 1}" %>
-          <h3 class="tab-accordion_heading" rel="<%= tab_id %>">
+          <h3 class="tab-marker tab-accordion_heading" rel="<%= tab_id %>">
             <%= category[:kind] %> <% if category[:version_info] %><span class="plugin-info"><%= category[:version_info] %></span><% end %>
           </h3>
 

--- a/source/plugins.html.erb
+++ b/source/plugins.html.erb
@@ -142,11 +142,6 @@ meta_keywords: "GoCD, continuous delivery, software, continuous integration, ope
 
 <script>
  jQuery(document).ready(function($) {
-   startTabContainer($);
-
-   if(window.location.hash) {
-       var id = window.location.hash.substring(1).replace(/\./g,'-');
-       $('#'+id).click();
-   }
+   startTabContainer();
  });
 </script>

--- a/source/releases.html.erb
+++ b/source/releases.html.erb
@@ -50,6 +50,6 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
 </main>
 <script>
 jQuery(document).ready(function($) {
-  startTabContainer($);
+  startTabContainer();
 });
 </script>

--- a/source/releases.html.erb
+++ b/source/releases.html.erb
@@ -28,15 +28,15 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
   <% end.sort.reverse.collect(&:to_s) %>
 
   <div class="v-tabs all-releases">
-    <ul class="tabs">
+    <ul class="tabs tab-container-marker">
       <%  releases.each_with_index do |release, index| %>
-      <li rel="tab-<%= release.gsub('.', '-') %>"<%= ' class="active"' if index == 0 %>><%= release %><%= ' (latest)' if index == 0 %></li>
+      <li rel="tab-<%= release.gsub('.', '-') %>" class="tab-marker<%= ' active' if index == 0 %>"><%= release %><%= ' (latest)' if index == 0 %></li>
       <% end %>
     </ul>
 
-    <div class="tab_container">
+    <div class="tab_container tab-container-marker">
       <%  releases.each_with_index do |release, index| %>
-      <h3 class="tab-accordion_heading<%= ' d_active' if index == 0 %>" rel="tab-<%= release.gsub('.', '-')%>"><%= release %><%= ' (latest)' if index == 0 %></h3>
+      <h3 class="tab-marker tab-accordion_heading<%= ' d_active' if index == 0 %>" rel="tab-<%= release.gsub('.', '-')%>"><%= release %><%= ' (latest)' if index == 0 %></h3>
       <div id="tab-<%= release.gsub('.', '-')%>" class="tab_content" style="display: block;">
         <div class="content">
           <%= partial "partials/release_notes/release-#{release.gsub('.', '-')}" %>


### PR DESCRIPTION
Will squash merge.

* Stop depending on click events generated using jQuery for everything.
* Small formatting and color changes (asked by Emily).
* Fix sorting of AMI versions.
* Show loading indicator when downloading.
* Cache downloaded JSON. Don't keep downloading during every click.
* Remove "Archive" tab. Old releases will show everything now.
* Fix bug of content going away when switching OSes.
* Simplify some tab-related code.