### PR TITLE
Tab improvements

### DIFF
--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -133,9 +133,14 @@ var newSetupShowVerifyChecksumMessage = (function ($) {
 })(jQuery);
 
 var determinePackageNameBasedOnOS = function () {
+  var userDefinedPackageName = window.location.hash.substr(1);
+  var validPackageNames = ['zip', 'windows', 'osx', 'debian', 'redhat', 'ami', 'docker'];
+  if (userDefinedPackageName !== "" && validPackageNames.includes(userDefinedPackageName)) {
+    return userDefinedPackageName;
+  }
+
   var userAgent = navigator.userAgent;
   var packageName = 'zip';
-
   if (userAgent.indexOf("Win") !== -1) packageName = "windows";
   if (userAgent.indexOf("Mac") !== -1) packageName = "osx";
   if (userAgent.indexOf("Debian") !== -1) packageName = "debian";

--- a/source/assets/javascripts/app/_tabs.js
+++ b/source/assets/javascripts/app/_tabs.js
@@ -1,5 +1,6 @@
 /*
- Expects something like the snippet below. Only the class names and IDs are important. Not the tags:
+ Expects something like the snippet below. Only the class names and IDs are important. Not the tags. Also, the tab
+ ID should start with "tab-" (assumption):
 
  <ul class="tab-container-marker">
    <li><span class="tab-marker" rel="tab-id-1">Tab 1</li>
@@ -21,7 +22,7 @@ var startTabContainer = (function ($) {
     $(".tab-container-marker .tab-marker:first").addClass("active").addClass("d_active");
 
     $("body").on('click', '.tab-container-marker .tab-marker', function () {
-      switchActiveTab($(this).attr('rel'));
+      switchActiveTab($(this).attr('rel').replace(/^tab-/, ''));
     });
 
     if (window.location.hash) {
@@ -31,9 +32,16 @@ var startTabContainer = (function ($) {
 })(jQuery);
 
 var switchActiveTab = function (tabIdentifier) {
+  const newTabContent = $(".tab_content#tab-" + tabIdentifier);
+  if (newTabContent.size() === 0) {
+    return;
+  }
+
   $(".tab_content").hide();
-  $(".tab_content#" + tabIdentifier).fadeIn();
+  newTabContent.fadeIn();
 
   $(".tab-container-marker .tab-marker").removeClass("active").removeClass("d_active");
-  $(".tab-container-marker .tab-marker[rel='" + tabIdentifier + "']").addClass("active").addClass("d_active");
+  $(".tab-container-marker .tab-marker[rel='tab-" + tabIdentifier + "']").addClass("active").addClass("d_active");
+
+  window.location.hash = tabIdentifier;
 };

--- a/source/assets/stylesheets/scss/_plugins.scss
+++ b/source/assets/stylesheets/scss/_plugins.scss
@@ -283,6 +283,6 @@ $actions-bg-hover: $primary-color;
   margin: -6px 0 10px 0;
 }
 
-#tab-9 .plugins-list li:last-child {
+#tab-commercial .plugins-list li:last-child {
     display:none;
 }

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -385,14 +385,14 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 
       newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
         .done(function () {
-          switchActiveTab('tab-' + currentOSPackageType);
+          switchActiveTab(currentOSPackageType);
         });
     });
 
     newShowDownloadLinks({typeOfInstallersToShow: currentInstallerType})
       .done(function () {
         startTabContainer();
-        switchActiveTab('tab-' + currentOSPackageType);
+        switchActiveTab(currentOSPackageType);
       });
 
     newSetupShowVerifyChecksumMessage();

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -100,11 +100,19 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
             Instructions</a></li>
         </ul>
         <p>If you need help downloading, installing or using GoCD please join the <a href="https://groups.google.com/forum/#!forum/go-cd" target="_blank">GoCD Users Google Group</a>.</p>
+
         <div class='subscribe-to-blog blogpost'>
-          <h3 class='subscribe-title'> Subscribe for updates on new GoCD releases</h3>
-          <script src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
-          <form id="mktoForm_6699"></form>
-          <script>MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 6699);</script>
+          <h3 class='subscribe-title'>Subscribe for information on new GoCD releases</h3>
+          <div id="subscribe-info">
+            Send us a mail to <a href="mailto:support@thoughtworks.com?subject=Sign%20me%20up%20for%20GoCD%20release%20notifications">support@thoughtworks.com</a> and we will sign you up.
+          </div>
+          <script type="text/javascript">
+            function initMarketoForm() {
+              jQuery("#subscribe-info").html("<form id='mktoForm_6699'></form>");
+              MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 6699);
+            }
+          </script>
+          <script async="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
         </div>
       </div>
     </div>

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -186,6 +186,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     </div>
   </div>
   {{/inline}}
+
+
   {{#*inline "show-amis"}}
   {{#if latest_cloud_release}}
   <div id="{{{tab_id}}}" class="tab_content {{{installer_type}}}">
@@ -226,6 +228,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   </div>
   {{/if}}
   {{/inline}}
+
+
   {{#*inline "show-ami-release"}}
   <h3>Demo AMI</h3>
   {{> ami-table amis=demo_amis}}
@@ -240,6 +244,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     {{> ami-table amis=server_amis}}
   </div>
   {{/inline}}
+
+
   {{#*inline "ami-table"}}
   <table class="table">
     <tr>
@@ -254,14 +260,16 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     {{/each}}
   </table>
   {{/inline}}
+
+
   {{#*inline "show-docker"}}
   {{#if latest_cloud_release}}
   <div id="{{{tab_id}}}" class="tab_content {{{installer_type}}}">
     <div class="latest">
       {{#with latest_cloud_release}}
       <div class="go-release {{go_version}}">
-      <div class=" col-xs-12 col-sm-2 ">
-        <span class="version">{{go_version}}</span>
+        <div class=" col-xs-12 col-sm-2 ">
+          <span class="version">{{go_version}}</span>
         </div>
       </div>
       <div class="col-xs-12 col-sm-10 ">
@@ -291,6 +299,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   </div>
   {{/if}}
   {{/inline}}
+
+
   {{#*inline "show-docker-release"}}
   <div class="files">
     <h3>GoCD Server Docker Image</h3>
@@ -307,11 +317,15 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     </ul>
   </div>
   {{/inline}}
+
+
   {{#*inline "show-docker-command"}}
   <li><a href="https://hub.docker.com/r/gocd/{{image_name}}">{{image_name}}</a>
     <span class="command">docker pull gocd/{{image_name}}:v{{version}}</span>
   </li>
   {{/inline}}
+
+
   {{#*inline "show-server-and-agent-32-and-64-bit-installers"}}
   <div class="download-files">
     {{> show-file server type="server" display_name="Server" info="(64 bit JRE)" os=../../installer_type}}
@@ -322,12 +336,16 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     {{> show-file agent32bit type="agent32bit" display_name="Agent" info="(32 bit JRE)" os=../../installer_type}}
   </div>
   {{/inline}}
+
+
   {{#*inline "show-server-and-agent-installer"}}
   <div>
     {{> show-file server type="server" display_name="Server" os=../../installer_type}}
     {{> show-file agent type="agent" display_name="Agent" os=../../installer_type}}
   </div>
   {{/inline}}
+
+
   {{#*inline "show-file"}}
   <div class="{{{type}}} file">
     <div class="name">
@@ -344,6 +362,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     </div>
   </div>
   {{/inline}}
+
+
   <div class="download-area">
   </div>
   <div class="os-tab-content">

--- a/source/download_new.html.erb
+++ b/source/download_new.html.erb
@@ -267,13 +267,13 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   <div id="{{{tab_id}}}" class="tab_content {{{installer_type}}}">
     <div class="latest">
       {{#with latest_cloud_release}}
-      <div class="go-release {{go_version}}">
-        <div class=" col-xs-12 col-sm-2 ">
+      <div class="go-release {{go_version}} row">
+        <div class=" col-xs-12 col-sm-2">
           <span class="version">{{go_version}}</span>
         </div>
-      </div>
-      <div class="col-xs-12 col-sm-10 ">
-      {{> show-docker-release server_docker=server_docker agents_docker=agents_docker}}
+        <div class="col-xs-12 col-sm-10">
+          {{> show-docker-release server_docker=server_docker agents_docker=agents_docker}}
+        </div>
       </div>
       {{/with}}
     </div>

--- a/source/plugins.html.erb
+++ b/source/plugins.html.erb
@@ -44,28 +44,28 @@ meta_keywords: "GoCD, continuous delivery, software, continuous integration, ope
     </p>
 
     <% plugin_categories = [
-      {kind: "Package repository plugins", version_info: ">= GoCD v13.3", plugins: data.repo_plugins},
-      {kind: "Task plugins", version_info: ">= GoCD v14.1", plugins: data.task_plugins},
-      {kind: "Notification plugins", plugins: data.notification_plugins},
-      {kind: "SCM plugins", plugins: data.scm_plugins},
-      {kind: "Authentication plugins", plugins: data.auth_plugins, deprecated: true, deprecation_message: "Authentication plugins are deprecated from GoCD v17.5.0"},
-      {kind: "Elastic agents plugins", version_info: ">= GoCD v16.8", plugins: data.elastic_agent_plugins},
-      {kind: "Configuration Repository", version_info: ">= GoCD v16.7", plugins: data.config_repo_plugins},
-      {kind: "Authorization plugins", version_info: ">= GoCD v17.5", plugins: data.authorization_plugins},
-      {kind: "Commercial Offerings", plugins: data.paid_plugins}
+        {id: 'authorization', kind: "Authorization plugins", version_info: ">= GoCD v17.5", plugins: data.authorization_plugins},
+        {id: 'config-repo', kind: "Configuration Repository", version_info: ">= GoCD v16.7", plugins: data.config_repo_plugins},
+        {id: 'elastic-agents', kind: "Elastic agents plugins", version_info: ">= GoCD v16.8", plugins: data.elastic_agent_plugins},
+        {id: 'notification', kind: "Notification plugins", plugins: data.notification_plugins},
+        {id: 'package-repo', kind: "Package repository plugins", version_info: ">= GoCD v13.3", plugins: data.repo_plugins},
+        {id: 'scm', kind: "SCM plugins", plugins: data.scm_plugins},
+        {id: 'task', kind: "Task plugins", version_info: ">= GoCD v14.1", plugins: data.task_plugins},
+        {id: 'authentication', kind: "Authentication plugins", plugins: data.auth_plugins, deprecated: true, deprecation_message: "Authentication plugins are deprecated from GoCD v17.5.0"},
+        {id: 'commercial', kind: "Commercial Offerings", plugins: data.paid_plugins}
     ] %>
     <div class="v-tabs all-plugins">
       <ul class="tabs tab-container-marker">
-        <% plugin_categories.each_with_index do |category, index| %>
-          <li class="tab-marker" rel="tab-<%= index + 1 %>" id="<%= category[:kind].downcase.gsub(' ','-')%>">
+        <% plugin_categories.each do |category| %>
+          <li class="tab-marker" rel="tab-<%= category[:id] %>" id="<%= category[:kind].downcase.gsub(' ','-')%>">
             <%= category[:kind] %> <% if category[:version_info] %><span class="plugin-info"><%= category[:version_info] %></span><% end %>
           </li>
         <% end %>
       </ul>
 
       <div class="tab_container tab-container-marker">
-        <% plugin_categories.each_with_index do |category, index| %>
-          <% tab_id = "tab-#{index + 1}" %>
+        <% plugin_categories.each do |category| %>
+          <% tab_id = "tab-#{category[:id]}" %>
           <h3 class="tab-marker tab-accordion_heading" rel="<%= tab_id %>">
             <%= category[:kind] %> <% if category[:version_info] %><span class="plugin-info"><%= category[:version_info] %></span><% end %>
           </h3>

--- a/source/releases.html.erb
+++ b/source/releases.html.erb
@@ -16,7 +16,7 @@ meta_keywords: "GoCD, continuous delivery, goforcd, open source, software, contr
 
 <div class="container">
   <p>
-    Check out "Enhancements" and "Bug fixes" for specific versions of Go below. As always, feel free to tell us what you think, or file a bug on <a href="https://github.com/gocd/gocd/issues/new" target="_blank">GitHub</a>.
+    Check out "Enhancements" and "Bug fixes" for specific versions of GoCD below. As always, feel free to tell us what you think, or file a bug on <a href="https://github.com/gocd/gocd/issues/new" target="_blank">GitHub</a>.
   </p>
   <p>
     <span>We try our best to credit all contributors. Apologies if we miss you out. Let us know and we will change this.</span>


### PR DESCRIPTION
- Show tab name in URL bar (Click on a tab, check URL bar)
- Can go directly to packages for an OS (`/downloads_new#debian`)
- Use proper tab names on plugin page (`/plugins#elastic-agents`)
- Docker images tab: Links are now clickable
- Async marketo code (not necessarily about tabs, I know, sorry)