### PR TITLE
Show only the last 12 releases made.

### DIFF
--- a/source/assets/javascripts/app/_download_new.js
+++ b/source/assets/javascripts/app/_download_new.js
@@ -23,6 +23,12 @@ var newShowDownloadLinks = (function ($) {
 
     var settings = settingsForAllTypes[typeOfInstallersToShow];
 
+    var dateFilter = R.curry(function (timeInSecondsSinceEpoch) {
+      return (new Date() - new Date(timeInSecondsSinceEpoch * 1000)) < 3600 * 24 * 366 * 1000;
+    });
+
+    var releasesLessThanAYearOld = R.filter(R.where({release_time: dateFilter}));
+
     var addURLToFiles = function (release) {
       var addDetailsFrom = R.curry(function (release, analyticsIDPrefix, o) {
         var afterAddingURL = R.assoc('url', settings.download_prefix + release['go_full_version'] + '/' + o["file"], o);
@@ -83,8 +89,9 @@ var newShowDownloadLinks = (function ($) {
         return latestRelease;
       };
 
-      var releases = R.compose(R.sort(compareVersions('go_full_version')), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
-      var amiReleases = R.sort(compareVersions('go_version'))(amiData[0]);
+      var releases = R.compose(releasesLessThanAYearOld, R.sort(compareVersions('go_full_version')), R.map(addURLToFiles), R.map(addDisplayVersion))(releaseData[0]);
+      var amiReleases = R.slice(0, releases.length, R.sort(compareVersions('go_version'))(amiData[0]));
+
       var latest_cloud_release = R.head(amiReleases);
       var other_cloud_releases = R.tail(amiReleases);
       var latestRelease = addInfo(R.head(releases));


### PR DESCRIPTION
* Since we support only the last 12 releases made, showing all the releases might prompt some users to download unsupported versions.
* Users asking for old releases are very rare. We can find the path from releases.json for such cases.
* Also, feedback from @maheshp was that it seemed like a lot of boxes to show. 

@arvindsv - thought about providing a `showAll=true` option in the url but decided against it. But, I can add it if you can tell me whether the frequency of these requests for old releases is high. 
 