### PR TITLE
Add t04glovern/gocd-spark-build-notifier to listing.

### DIFF
--- a/data/notification_plugins.yml
+++ b/data/notification_plugins.yml
@@ -105,3 +105,13 @@
   releases_url: https://github.com/gocd-contrib/gitter-activity-feed-plugin/releases
   github_stars: http://ghbtns.com/github-btn.html?user=gocd-contrib&repo=gitter-activity-feed-plugin&type=watch&count=true
   first_available_date: 11/2016
+
+- name: Spark Build Notifier
+  description: Plugin to get build notifications on Cisco Spark.
+  readmore_url: https://github.com/t04glovern/gocd-spark-build-notifier
+  author_url: https://github.com/t04glovern
+  author_name: Nathan Glover
+  releases_url: https://github.com/t04glovern/gocd-spark-build-notifier/releases
+  github_stars: http://ghbtns.com/github-btn.html?user=t04glovern&repo=gocd-spark-build-notifier&type=watch&count=true
+  first_available_date: 02/2018
+  


### PR DESCRIPTION
Added Cisco Spark build notifier plugin to the notification plugins page