### PR TITLE
Adding Okta OAuth authorization plugin

### DIFF
--- a/data/authorization_plugins.yml
+++ b/data/authorization_plugins.yml
@@ -49,6 +49,15 @@
   github_stars: http://ghbtns.com/github-btn.html?user=gocd-contrib&repo=google-oauth-authorization-plugin&type=watch&count=true
   paid: false
 
+- name: Okta OAuth authorization plugin
+  description: The plugin allows user to login in GoCD using an Okta account.
+  readmore_url: https://github.com/szamfirov/gocd-okta-oauth-authorization-plugin
+  author_url: https://github.com/szamfirov
+  author_name: Svetlin Zamfirov
+  releases_url: https://github.com/szamfirov/gocd-okta-oauth-authorization-plugin/releases
+  github_stars: http://ghbtns.com/github-btn.html?user=szamfirov&repo=gocd-okta-oauth-authorization-plugin&type=watch&count=true
+  paid: false
+
 - name: TLS Client Certificate Authentication plugin
   description: Using headers set by a TLS-terminating reverse proxy, details from a client certificate are used to log in
   readmore_url: https://github.com/cnorthwood/gocd-tls-auth


### PR DESCRIPTION
This is adding the [Okta OAuth authorization plugin](https://github.com/szamfirov/gocd-okta-oauth-authorization-plugin) in the **plugins** section of the website.