### PR TITLE
Documentation top-level navlink needs a current-page indicator

### DIFF
--- a/source/assets/stylesheets/scss/_navigation.scss
+++ b/source/assets/stylesheets/scss/_navigation.scss
@@ -306,6 +306,7 @@ ul.level1 {
 .blog .link_blog,
 .help .toplink_help,
 .resources .toplink_help,
+.resources .link_documentation,
 .download .link_download,
 .enterprise .link_enterprise {
     @media screen and (max-width: $screen-xs-max) {

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -3,8 +3,8 @@
     <%= link_to image_tag('go_logo.svg', {:title => 'GoCD Logo', :alt => 'GoCD Logo'}), '/index.html', {:class => 'logo', "analytics-label" => 'logo'} %>
     <nav class="mainnav">
       <ul class="level0">
-        <li><%= link_to 'Features', '/why-gocd/index.html' , :class => 'link_whygocd', "analytics-label" => "link_whygocd" %></li>
-        <li><%= link_to 'Documentation', '/resources.html', :target => '_blank', "analytics-label" => "link_help>link_documentation" %></li>
+        <li><%= link_to 'Features', '/why-gocd/index.html', :class => 'link_whygocd', "analytics-label" => "link_whygocd" %></li>
+        <li><%= link_to 'Documentation', '/resources.html', :class => "link_documentation", "analytics-label" => "link_help>link_documentation" %></li>
         <li><%= link_to 'Blog', '/blog/index.html' ,:class => 'link_blog', "analytics-label" => "Blog" %></li>
 
         <li class="dropdown"><%= link_to 'Enterprise', "/enterprise/index.html" ,:class => 'link_enterprise', "analytics-label" => "Enterprise" %>


### PR DESCRIPTION
The target should also open in the current window, as opposed to a new tab.