### PR TITLE
Hide the purple triangle on hover when the navlinks are vertically st…

### DIFF
--- a/source/assets/stylesheets/scss/_navigation.scss
+++ b/source/assets/stylesheets/scss/_navigation.scss
@@ -8,18 +8,20 @@ $secondary-nav-color: #25282D;
 $navbar-dark: #1B1D21;
 
 @mixin navlink-indicator {
-    &:before {
-        content: "";
-        position: absolute;
-        height: 0;
-        border-style: solid;
-        border-width: 10px 10px 0px 10px;
-        border-color: $primary-color transparent transparent transparent;
-        left: 50%;
-        transform: translateX(-50%);
-        top: 0px;
-        width: 20px;
-        transition: all 0.3s ease;
+    @media screen and (min-width: $screen-tablet) {
+        &:before {
+            content: "";
+            position: absolute;
+            height: 0;
+            border-style: solid;
+            border-width: 10px 10px 0px 10px;
+            border-color: $primary-color transparent transparent transparent;
+            left: 50%;
+            transform: translateX(-50%);
+            top: 0px;
+            width: 20px;
+            transition: all 0.3s ease;
+        }
     }
 }
 


### PR DESCRIPTION
Hover indicator should not show on navlinks when responsive rules force them to stack:

![image](https://user-images.githubusercontent.com/723642/39072826-99e19778-44a0-11e8-97a2-9cf10fdcb23d.png)
