### PR TITLE
updated get tix to register

### DIFF
--- a/source/events.html.erb
+++ b/source/events.html.erb
@@ -52,7 +52,7 @@ meta_keywords: "GoCD, continuous delivery, open source, community, events, learn
               <div class="event-title-container">
                 <span class="event-title"><%= event.title %></span>
               </div>
-              <a href="<%= event.url %>" class="event-button">Get Tickets</a>
+              <a href="<%= event.url %>" class="event-button">Register</a>
             </div>
 
             <div class="event-description-container">


### PR DESCRIPTION
"Get tickets" didn't make sense in the context of all the events in this section, changing to "Register"