### PR TITLE
Ensure marketo load error message displays when load fails for any reason

### DIFF
--- a/source/assets/javascripts/marketo_popover.js
+++ b/source/assets/javascripts/marketo_popover.js
@@ -1,13 +1,31 @@
 (function ($) {
   "use strict";
 
+  function isFirefox() {
+    return !!navigator.userAgent.match(/(mozilla|gecko|firefox)/i)
+  }
+
+  var LOAD_ERR_MSG = "It looks like our signup form was blocked by an adblocker in your browser! Please email us directly or pause your adblocker to use the form.",
+      LOAD_ERR_MSG_FFOX = "It looks like our signup form was blocked by Firefox! Please email us directly or try a different broswer to use the form.";
+
   function MarketoForm() {
-    var displayOverlay = function() {
+    function displayOverlay() {
       $('.overlay').show();
 
-      setTimeout(function() {
+      setTimeout(function hideOverlay() {
         $('.overlay').hide();
       }, 5000);
+    }
+
+    this.mailToFallback = function mailToFallback(id) {
+      try {
+        MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", parseInt(id, 10));
+        $("#backup-subscription-message").remove();
+      } catch(e) {
+        if (console && "function" === console.warn) {
+          console.warn("Failed to load Marketo form; reason:", e);
+        }
+      }
     };
 
     this.init = function init(id) {
@@ -26,7 +44,7 @@
           });
         });
       } catch(e) {
-        $('.form-loading-error').show();
+        $('.form-loading-error').text(isFirefox() ? LOAD_ERR_MSG_FFOX : LOAD_ERR_MSG).show();
       }
     };
   }

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -106,13 +106,8 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
               and we will sign you up.
             </div>
           </div>
-          <script type="text/javascript">
-            function initMarketoForm() {
-              MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 6699);
-              jQuery("#backup-subscription-message").remove();
-            }
-          </script>
-          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
+          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+          <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().mailToFallback(6699)"></script>
         </div>
       </div>
     </div>

--- a/source/enterprise-campaign/index.html.erb
+++ b/source/enterprise-campaign/index.html.erb
@@ -97,12 +97,10 @@ show_features: true
               </div>
             </div>
           </div>
-          <script defer="true" src="/assets/javascripts/marketo_popover.js"></script>
-          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="new MarketoForm().init(7582)"></script>
           <form id="mktoForm_7582"></form>
-          <div class="form-loading-error">
-            It looks like our signup form was blocked by an adblocker in your browser! Please email us directly or pause your adblocker to use the form.
-          </div>
+          <div class="form-loading-error"></div>
+          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+          <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().init(7582)"></script>
         </div>
       </div>
     </div>

--- a/source/enterprise/contact.html.erb
+++ b/source/enterprise/contact.html.erb
@@ -15,12 +15,10 @@
         </div>
 
         <div class="content-card-six-column enterprise-marketo-style contact-marketo">
-          <script defer="true" src="/assets/javascripts/marketo_popover.js"></script>
-          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="new MarketoForm().init(7582)"></script>
           <form id="mktoForm_7582"></form>
-          <div class="form-loading-error">
-            It looks like our signup form was blocked by an adblocker in your browser! Please email us directly or pause your adblocker to use the form.
-          </div>
+          <div class="form-loading-error"></div>
+          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+          <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().init(7582)"></script>
         </div>
       </div>
     </div>

--- a/source/enterprise/support.html.erb
+++ b/source/enterprise/support.html.erb
@@ -12,12 +12,10 @@
           </div>
         </div>
         <div class="content-card-six-column enterprise-marketo-style support-marketo">
-          <script defer="true" src="/assets/javascripts/marketo_popover.js"></script>
-          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="new MarketoForm().init(2357)"></script>
           <form id="mktoForm_2357"></form>
-          <div class="form-loading-error">
-            It looks like our signup form was blocked by an adblocker in your browser! Please email us directly or pause your adblocker to use the form.
-          </div>
+          <div class="form-loading-error"></div>
+          <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+          <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().init(2357)"></script>
         </div>
       </div>
 

--- a/source/partials/_post-page_subscribe_to_blog.html.erb
+++ b/source/partials/_post-page_subscribe_to_blog.html.erb
@@ -9,11 +9,6 @@
           to subscribe to the Pipeline newsletter.
       </div>
     </div>
-    <script type="text/javascript">
-      function initMarketoForm() {
-        MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 5414);
-        jQuery("#backup-subscription-message").remove();
-      }
-    </script>
-    <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
+    <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+    <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().mailToFallback(5414)"></script>
 </div>

--- a/source/partials/_subscribe_to_blog.html.erb
+++ b/source/partials/_subscribe_to_blog.html.erb
@@ -13,13 +13,8 @@
           to subscribe to the Pipeline newsletter.
       </div>
     </div>
-    <script type="text/javascript">
-      function initMarketoForm() {
-        MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 5414);
-        jQuery("#backup-subscription-message").remove();
-      }
-    </script>
-    <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
+    <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+    <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().mailToFallback(5414)"></script>
   </div>
 </div>
 </div>

--- a/source/sales-sign-up.html.erb
+++ b/source/sales-sign-up.html.erb
@@ -22,13 +22,8 @@ meta_keywords: "GoCD, continuous delivery, continuous delivery software, continu
           It looks like you might have a browser extension blocking the sign up form. Please send us a mail to <a href="mailto:support@thoughtworks.com?subject=Sign%20me%20up%20for%20GoCD%20support%20trial&amp;body=Hello,%0a%0aPlease%20contact%20me%20and%20provide%20a%20trial%20of%20GoCD%20support.%20My%20details%20are:%0a%0aFirst%20Name:%0aLast%20Name:%0aCompany%20Name:%0aRole:%0aCountry:%0aComments:%0a%0aThank%20you.">support@thoughtworks.com</a> to sign up for this.
         </div>
       </div>
-      <script type="text/javascript">
-        function initMarketoForm() {
-          MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 6280);
-          jQuery("#backup-subscription-message").remove();
-        }
-      </script>
-      <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
+      <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+      <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().mailToFallback(6280)"></script>
     </div>
   </div>
 </main>

--- a/source/subscribe.html.erb
+++ b/source/subscribe.html.erb
@@ -44,13 +44,8 @@ meta_keywords: "GoCD, feature announcements, release announcements, continuous d
           Send us a mail to <a href="mailto:support@thoughtworks.com?subject=Sign%20me%20up%20for%20the%20GoCD%20mailing%20list&amp;body=Hello,%0a%0aPlease%20sign%20me%20up.%20My%20details%20are:%0a%0aFirst%20Name:%0aLast%20Name:%0aCompany%20Name:%0a%0aI%20would%20like%20to%20hear%20about:%0a%20%20-%20Product%20updates%0a%20%20-%20Product%20learning%20sessions%0a%20%20-%20Enterprise%20features%20and%20support%0a%20%20-%20The%20Pipeline%20newsletter%0a%0aThank%20you.">support@thoughtworks.com</a> to subscribe to this.
         </div>
       </div>
-      <script type="text/javascript">
-        function initMarketoForm() {
-          MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 3085);
-          jQuery("#backup-subscription-message").remove();
-        }
-      </script>
-      <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js" onload="initMarketoForm()"></script>
+      <script defer="true" src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+      <script defer="true" src="/assets/javascripts/marketo_popover.js" onload="new MarketoForm().mailToFallback(3085)"></script>
     </div>
   </div>
 </div>


### PR DESCRIPTION

  - Swapped script load order to satisfy dependencies
  - marketo_popover.js now holds all marketo fallback logic
  - Special message for Firefox users as there is built-in tracker blocking