### PR TITLE
Add missing releases URL for Docker Registry Artifact Plugin

### DIFF
--- a/data/plugins/artifact_plugins.yml
+++ b/data/plugins/artifact_plugins.yml
@@ -4,3 +4,4 @@
   author_url: http://www.thoughtworks.com/products/
   author_name: ThoughtWorks Inc.
   github_stars: http://ghbtns.com/github-btn.html?user=gocd&repo=docker-registry-artifact-plugin&type=watch&count=true
+  releases_url: https://github.com/gocd/docker-registry-artifact-plugin/releases

--- a/data/plugins/authorization_plugins.yml
+++ b/data/plugins/authorization_plugins.yml
@@ -19,7 +19,7 @@
   readmore_url: https://extensions-docs.gocd.org/ldap/current/
   author_url: https://www.thoughtworks.com/products/
   author_name: ThoughtWorks Inc.
-  contact_url: https://www.thoughtworks.com/go/#pricing
+  contact_url: https://www.gocd.org/enterprise/pricing/
   paid: true
   
 - name: Atlassian Crowd Authentication Plugin

--- a/data/plugins/elastic_agent_plugins.yml
+++ b/data/plugins/elastic_agent_plugins.yml
@@ -3,7 +3,7 @@
   readmore_url: https://extensions-docs.gocd.org/ecs/current/
   author_url: https://www.thoughtworks.com/products/
   author_name: ThoughtWorks Inc.
-  contact_url: https://www.thoughtworks.com/go/#pricing
+  contact_url: https://www.gocd.org/enterprise/pricing/
   paid: true
 
 - name: GoCD Elastic agent plugin for Docker


### PR DESCRIPTION
The current download link for the plugin is broken.

Edit: Also piggybacking another couple of URL changes with this PR -- the URL for the pricing link is updated.