### PR TITLE
Updates to the getting started dropdown

### DIFF
--- a/source/assets/javascripts/app/_getting_started.js
+++ b/source/assets/javascripts/app/_getting_started.js
@@ -16,12 +16,14 @@ jQuery(document).ready(function($) {
   var setupSidebar = function() {
     $('nav.getting-started-nav ul.verticalnav > li.dropdown > a').click(function(e){
       e.preventDefault();
-      var isOpen = $(this).parent().hasClass('open');
-      $('nav.getting-started-nav ul.verticalnav > li.dropdown > ul').hide();
-      $('nav.getting-started-nav ul.verticalnav > li.dropdown').removeClass('open');
+      var parent = $(this).parent();
+      var isOpen = parent.hasClass('open');
+
+      $(this).next('ul').hide();
+      parent.removeClass('open');
       if(!isOpen) {
-        $(this).parent().addClass('open');
-        $(this).parent().find('ul').show();  
+        parent.addClass('open');
+        parent.find('ul').show();
       }
     });
   };

--- a/source/assets/stylesheets/scss/_getting-started.scss
+++ b/source/assets/stylesheets/scss/_getting-started.scss
@@ -192,20 +192,21 @@ nav.sidebar-nav {
 
         >a {
           color: #fff;
+          &:after {
+            content: "";
+            position: absolute;
+            right: 10px;
+            top: 14px;
+            border-top: 5px solid transparent;
+            border-bottom: 5px solid transparent;
+            border-left: 5px solid #fff;
+          }
         }
 
-        &:after {
-          content: "";
-          position: absolute;
-          right: 10px;
-          top: 14px;
-          border-top: 5px solid transparent;
-          border-bottom: 5px solid transparent;
-          border-left: 5px solid #fff;
-        }
 
         &.open {
-          &:after {
+          >a {
+            &:after {
             content: "";
             position: absolute;
             right: 12px;
@@ -213,8 +214,8 @@ nav.sidebar-nav {
             border-left: 5px solid transparent;
             border-right: 5px solid transparent;
             border-top: 5px solid #fff;
+           }
           }
-
         }
 
       }


### PR DESCRIPTION
I moved the caret for the introduction to GoCD dropdown to the link (vs the li) since the click handler is on the link (not the li). This way when you click on the caret itself the menu will expand or collapse which is intuitive and the behavior I would expect. 

I also changed the behavior of the collapsing to allow multiple sections ("Parts") to be open simultaneously. 