### PR TITLE
Show demo AMIs from multiple regions

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -254,29 +254,35 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 
   {{#*inline "show-ami-release"}}
   <h3>Demo AMI</h3>
-  {{> ami-table amis=demo_amis}}
+  {{> ami-table-with-dropdown amis=demo_amis}}
+
   <h3>Server AMI</h3>
-  {{#size server_amis 'eq' 1}}
-   <table class="table">
+  {{> ami-table-with-dropdown amis=server_amis}}
+  {{/inline}}
+
+
+  {{#*inline "ami-table-with-dropdown"}}
+  {{#size amis 'eq' 1}}
+  <table class="table">
     <tr>
       <th>Region</th>
       <th>AMI ID</th>
     </tr>
-    <tr class="{{server_amis.0.region}}">
-      <td>{{server_amis.0.region}}</td>
-      <td><a href="{{server_amis.0.href}}">{{server_amis.0.ami_id}}</a></td>
+    <tr class="{{amis.0.region}}">
+      <td>{{amis.0.region}}</td>
+      <td><a href="{{amis.0.href}}">{{amis.0.ami_id}}</a></td>
     </tr>
   </table>
   {{/size}}
-  {{#size server_amis 'gt' 1}}
+  {{#size amis 'gt' 1}}
   <div>Select a region</div>
   <div class="table-c">
     <select id="{{go_version}}" class="select-dropdown">
-      {{#each server_amis}}
+      {{#each amis}}
       <option value="{{region}}">{{region}}</option>
       {{/each}}
     </select>
-    {{> ami-table amis=server_amis}}
+    {{> ami-table amis=amis}}
   </div>
   {{/size}}
   {{/inline}}


### PR DESCRIPTION
Related to https://github.com/gocd/gocd-cloud/pull/10

Now that https://github.com/gocd/gocd-cloud/pull/10 adds demo AMIs to two regions (potentially), there needs to be a dropdown to show the AMIs across regions.

Can be merged before https://github.com/gocd/gocd-cloud/pull/10.