### PR TITLE
Remove additional padding on windows tab when there is no 32-bit and 64-bit info to show.

### DIFF
--- a/source/assets/stylesheets/scss/_downloads.scss
+++ b/source/assets/stylesheets/scss/_downloads.scss
@@ -606,7 +606,7 @@ body.download {
     }
   }
   #tab-windows {
-    .files {
+    .files .download-files {
       padding-top: 40px;
     }
   }


### PR DESCRIPTION
Used to be like this - 
<img width="845" alt="screen shot 2018-12-19 at 8 22 19 am" src="https://user-images.githubusercontent.com/4715748/50235224-45911c80-036c-11e9-8aef-b96877267e5d.png">

Older releases which show the 32-bit JRE and 64-bit JRE info is unaffected -

<img width="703" alt="screen shot 2018-12-19 at 8 57 47 am" src="https://user-images.githubusercontent.com/4715748/50235277-5e99cd80-036c-11e9-9cfc-0295f18be886.png">

