### PR TITLE
fix on content alignment

### DIFF
--- a/source/assets/stylesheets/scss/_campaign.scss
+++ b/source/assets/stylesheets/scss/_campaign.scss
@@ -242,7 +242,7 @@ h1.main-caption {
         text-align: center;
         font-size: 3em;
     }
-    .content_101 {
+    .content_cd101 {
         margin-bottom: 2em;
     }
     .cta {

--- a/source/assets/stylesheets/scss/_campaign.scss
+++ b/source/assets/stylesheets/scss/_campaign.scss
@@ -242,7 +242,7 @@ h1.main-caption {
         text-align: center;
         font-size: 3em;
     }
-    .content {
+    .content_101 {
         margin-bottom: 2em;
     }
     .cta {

--- a/source/cd101/index.html.erb
+++ b/source/cd101/index.html.erb
@@ -20,27 +20,27 @@ show_features: true
       <div class="col-sm-12">
         <h1>Free Guide: Introduction to Continuous Delivery</h1>
       </div>
-      
-      <div class="col-sm-4">
-        <%= image_tag 'campaign/cd101/815-booklet-mockup.jpg', alt: 'Download the CD101 eBook', title: "Download the CD101 eBook" %>
-      </div>
+      <div class="row">
+        <div class="col-sm-4">
+          <%= image_tag 'campaign/cd101/815-booklet-mockup.jpg', alt: 'Download the CD101 eBook', title: "Download the CD101 eBook" %>
+        </div>
 
-      <div class="col-sm-8 content">
+        <div class="col-sm-8 content_cd101">
 
-        <h3><b>Want to deploy code faster? React to changes quickly? Release more frequently?</b></h3>
+          <h3><b>Want to deploy code faster? React to changes quickly? Release more frequently?</b></h3>
+          
+          <p>In this Continuous Delivery 101 eBook, we’ll take you back to the  basics. Inside you’ll find a reference guide with visuals on key concepts.</p>     
         
-        <p>In this Continuous Delivery 101 eBook, we’ll take you back to the  basics. Inside you’ll find a reference guide with visuals on key concepts.</p>     
-      
-        <ul>
-          <li>What is continuous integration?</li>
-          <li>What is continuous delivery and continuous deployment? Are they different?</li>
-          <li>What is DevOps and how can you benefit from it?</li>
-          <li>Is your team ready for continuous delivery?</li>
-        </ul>
+          <ul>
+            <li>What is continuous integration?</li>
+            <li>What is continuous delivery and continuous deployment? Are they different?</li>
+            <li>What is DevOps and how can you benefit from it?</li>
+            <li>Is your team ready for continuous delivery?</li>
+          </ul>
 
-        <p>We also explore core development practices that are prerequisites for continuous delivery. We present questions you need to answer honestly about your own people, teams, and organization to determine your readiness for continuous delivery.</p>
+          <p>We also explore core development practices that are prerequisites for continuous delivery. We present questions you need to answer honestly about your own people, teams, and organization to determine your readiness for continuous delivery.</p>
+        </div>
       </div>
-
       <div class="col-md-12 cta">
       <%= link_to 'Download for free', "/assets/images/campaign/cd101/ebook-continuous-delivery-101.pdf", {:class => "btn btn-primary campaign-btn-download", "analytics-label" => "campaign-download-cta"} %>
       </div>


### PR DESCRIPTION
Content and image in the page GoCD 101, broken due to conflict in the style for the class `content`. Changed the classname to `content_cd101` to avoid conflict