### PR TITLE
Added notice to eula and general terms pages if they include '?redirected=true'

### DIFF
--- a/source/assets/javascripts/app/_main.js
+++ b/source/assets/javascripts/app/_main.js
@@ -160,4 +160,12 @@ jQuery(document).ready(function ($) {
 
   //why go-cd lightbox
   $('.chocolat-parent').Chocolat();
+
+  $(document).ready(function () {
+    var redirected = window.location.search.match(/(?:\?|&)redirected=([^&]+)(?:&|$)/);
+
+    if (redirected !== null && redirected[1] === "true") {
+     $('.redirect-notice').show();
+    }
+  });
 });

--- a/source/assets/stylesheets/enterprise/_utilities.scss
+++ b/source/assets/stylesheets/enterprise/_utilities.scss
@@ -285,6 +285,7 @@
 
 .redirect-notice {
   display: none;
+  font-style: italic;
 }
 
 .general-terms {

--- a/source/assets/stylesheets/enterprise/_utilities.scss
+++ b/source/assets/stylesheets/enterprise/_utilities.scss
@@ -283,6 +283,10 @@
     height: 10vh;
 }
 
+.redirect-notice {
+  display: none;
+}
+
 .general-terms {
 
     .section2 {

--- a/source/enterprise/thoughtworks-go-extensions-eula.html.erb
+++ b/source/enterprise/thoughtworks-go-extensions-eula.html.erb
@@ -2,7 +2,7 @@
 	<%= partial 'partials/secondarynav' %>
 	<div class="page-bottom-margin"></div>
 	<div class="container general-terms">
-
+    <div class="redirect-notice">This page was redirected from https://www.thoughtworks.com/go/thoughtworks-go-extensions-eula/</div>
 		<section class="section1">
     <div class="background">
         <h1>Thoughtworks Go Extensions <br/> End User License Agreement</h1>

--- a/source/enterprise/thoughtworks-support-services-general-terms.html.erb
+++ b/source/enterprise/thoughtworks-support-services-general-terms.html.erb
@@ -2,6 +2,7 @@
 	<%= partial 'partials/secondarynav' %>
 	<div class="page-bottom-margin"></div>
 	<div class="container general-terms">
+	<div class="redirect-notice">This page was redirected from https://www.thoughtworks.com/go/thoughtworks-support-services-general-terms/</div>
 
 	<section class="section1">
 	  <div class="background">


### PR DESCRIPTION
Because the assets for the microsite (www.thoughtworks.com/go) are missing, the CSS and images for the terms and eula pages are now broken. 

We've decided to redirect requests from www.thoughtworks.com/go/thoughtworks-go-extensions-eula to www.gocd.org/enterprise/thoughtworks-go-extensions-eula and www.thoughtworks.com/go/thoughtworks-support-services-general-terms to www.gocd.org/enterprise/thoughtworks-support-services-general-terms. 

Per Jeremy's request, we'd like to show a notice when the pages have been redirected. This PR gives us the option to do that using ?redirected=true