### PR TITLE
Fixes a broken link to Docker-Pipeline-Plugin

### DIFF
--- a/data/plugins/task_plugins.yml
+++ b/data/plugins/task_plugins.yml
@@ -189,7 +189,7 @@
 
 - name: Docker pipeline plugin
   description: Builds a docker image from a Dockerfile, tags it and pushes it to a registry.
-  readmore_url: https://github.com/Haufe-Lexware/gocd-plugins/wiki/Docker-pipeline-plugin
+  readmore_url: https://github.com/Haufe-Lexware/gocd-plugins/wiki/Docker-plugin
   author_url: https://github.com/bradeac
   author_name: Camil Bradea
   releases_url: https://github.com/Haufe-Lexware/gocd-plugins/releases


### PR DESCRIPTION
Fixes a more or less broken link (currently the link points to an empty wiki page) to the Haufe-Lexware Docker-Pipeline-Plugin.

I checked the other plugins-related links. They are fine.

Maybe the PR is too trivial – so, feel free to reject it.