### PR TITLE
[Don't merge yet] Add release dates in release notes

### DIFF
--- a/source/assets/stylesheets/scss/_releases.scss
+++ b/source/assets/stylesheets/scss/_releases.scss
@@ -31,6 +31,15 @@
       }
     }
 
+    .release-date {
+      float: right;
+      display: inline;
+
+      & + h4 {
+        margin: 0 0 30px 0;
+      }
+    }
+
     .alert.warning {
       background-color: #e68489cc;
       padding: 10px;

--- a/source/partials/next_release/_release.md.erb
+++ b/source/partials/next_release/_release.md.erb
@@ -1,6 +1,7 @@
-<h4> some feature </h4>
+<div class="release-date">Released on 25 Apr, 2019</div>
+<h4>Some new feature!</h4>
 
-Some info abt the feature
+Some info about the feature
 
 <h4>Other Improvements</h4>
 

--- a/source/partials/release_notes/_release-14-2-0.html.erb
+++ b/source/partials/release_notes/_release-14-2-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 13 Nov, 2014</div>
 <h4>Enhancements</h4>
 <ul>
   <li><a href="https://github.com/gocd/gocd/pull/190">190</a> - Git post commit hook to trigger Go pipeline.

--- a/source/partials/release_notes/_release-14-3-0.html.erb
+++ b/source/partials/release_notes/_release-14-3-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 13 Nov, 2014</div>
 <h4>New Features</h4>
 <ul>
   <li>

--- a/source/partials/release_notes/_release-14-4-0.html.erb
+++ b/source/partials/release_notes/_release-14-4-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 02 Jan, 2015</div>
 <h4>New Features</h4>
 <ul>
   <li><a href="https://github.com/gocd/gocd/issues/719">719</a> - JSON message based Plugin APIs (docs - <a href="https://plugin-api.gocd.org/current/package-repo/">package</a>,

--- a/source/partials/release_notes/_release-15-1-0.html.erb
+++ b/source/partials/release_notes/_release-15-1-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 29 Apr, 2015</div>
 <h4>New plugin endpoint for "Materials"</h4>
 <p> This new plugin endpoint introduced in 15.1 allows Go's already long list of source code materials to be extended without making changes to the core! </p>
 <p> Support for this endpoint brought along support for GitHub pull requests, contributed by an external contributor <a href="https://github.com/ashwanthkumar">@ashwanthkumar</a> (so exciting!), with support from a Go core contributor, <a href="https://github.com/srinivasupadhya/">@srinivasupadhya</a>.

--- a/source/partials/release_notes/_release-15-2-0.html.erb
+++ b/source/partials/release_notes/_release-15-2-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 14 Jul, 2015</div>
 <h4>Improvements to the console log</h4>
 <p>
   GoCD now supports rendering of ANSI color codes to show you much more beautiful console logs. Additionally, Go will automatically follow the logs as your build produces it, very much like your favorite terminal program.

--- a/source/partials/release_notes/_release-15-3-1.html.erb
+++ b/source/partials/release_notes/_release-15-3-1.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 24 Dec, 2015</div>
 <h4>What's new in GoCD 15.3.1</h4>
 <p><span class="text-important">Important</span>: 15.3.1 has been removed from the downloads page because it had an <a href="https://github.com/gocd/gocd/issues/1753">issue</a> which could have caused problems during configuration save. The issue
   mentioned is fixed in 16.1.0. The rest of the issues mentioned below are a part of 16.1.0 as well. We highly recommend upgrading to 16.1.0.</p>

--- a/source/partials/release_notes/_release-16-1-0.html.erb
+++ b/source/partials/release_notes/_release-16-1-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 18 Jan, 2016</div>
 <h4>What's new in GoCD 16.1</h4>
 <p>
   We are moving to a more regular release schedule, and so you might see releases with mostly issues fixed, while bigger level features are in progress across releases.

--- a/source/partials/release_notes/_release-16-10-0.html.erb
+++ b/source/partials/release_notes/_release-16-10-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 27 Sep, 2016</div>
 <h4>Agents page (Beta)</h4>
 
 <p>This is a new page for managing agents, which should feel a lot more light weight and snappier than the existing agents page.</p>

--- a/source/partials/release_notes/_release-16-11-0.html.erb
+++ b/source/partials/release_notes/_release-16-11-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 24 Oct, 2016</div>
 <h4>API enhancements</h4>
 
 <p><%= link_to_commit('fb24522', "Added new #{link_to_api 'elastic-agent-profiles'} to manage elastic agent profiles.") %></p>

--- a/source/partials/release_notes/_release-16-12-0.md.erb
+++ b/source/partials/release_notes/_release-16-12-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 12 Dec, 2016</div>
 <h4>UI Refresh</h4>
 
 The entire application has been refreshed to sport a flat look.

--- a/source/partials/release_notes/_release-16-2-1.html.erb
+++ b/source/partials/release_notes/_release-16-2-1.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 07 Mar, 2016</div>
 <p>
   <span class="text-important">Important</span>: 16.2 has been removed from the downloads page because it had an <a href="https://github.com/gocd/gocd/issues/1936">issue</a> which caused problems while installing windows agents.
 </p>

--- a/source/partials/release_notes/_release-16-3-0.html.erb
+++ b/source/partials/release_notes/_release-16-3-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 31 Mar, 2016</div>
 <h4>Security</h4>
 <p><strong>Important:</strong> This release fixes several XSS and CSRF vulnerabilities which can be exploited in earlier versions. As the changes are extensive, patches for older releases will not be provided. We recommend all users to upgrade to this version to safeguard your GoCD server.</p>
 <p>These security vulnerabilities were responsibly disclosed by <a href="https://github.com/drrb">drrb</a>. We want to give users some time to upgrade, before providing more details about the vulnerabilities. We will work with drrb on the specifics of providing these details, soon.</p>

--- a/source/partials/release_notes/_release-16-4-0.html.erb
+++ b/source/partials/release_notes/_release-16-4-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 21 Apr, 2016</div>
 <h4>Security</h4>
 
 <p>

--- a/source/partials/release_notes/_release-16-5-0.html.erb
+++ b/source/partials/release_notes/_release-16-5-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 25 May, 2016</div>
 <h4>Support for Java 8</h4>
 
 <p>

--- a/source/partials/release_notes/_release-16-6-0.html.erb
+++ b/source/partials/release_notes/_release-16-6-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 24 Jun, 2016</div>
 <h4>Whitelist support for SCM materials</h4>
 
 <p><%= link_to_pull_request(2314, 'Handling the triggering of a pipeline for monolithic repositories using a whitelist.') %></p>

--- a/source/partials/release_notes/_release-16-7-0.html.erb
+++ b/source/partials/release_notes/_release-16-7-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 29 Jul, 2016</div>
 <h4>GoCD configuration under SCM (a.k.a Config repositories)</h4>
 
 <p>

--- a/source/partials/release_notes/_release-16-8-0.html.erb
+++ b/source/partials/release_notes/_release-16-8-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 18 Aug, 2016</div>
 <h4>Beta Feature - Elastic agents</h4>
 
 <p>

--- a/source/partials/release_notes/_release-16-9-0.html.erb
+++ b/source/partials/release_notes/_release-16-9-0.html.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 02 Sep, 2016</div>
 <h4>Quick Edit (Beta)</h4>
 
 <p>Currently, editing a pipeline means navigating through multiple pages (and page refreshes), for modifying stages, jobs with tabs for options and environment variables, etc. Quick edit to make it smoother.</p>

--- a/source/partials/release_notes/_release-17-1-0.md.erb
+++ b/source/partials/release_notes/_release-17-1-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 18 Jan, 2017</div>
 <h4>Performance Improvement</h4>
 
 - <%= link_to_commit '2ae7fdb72e31b2868cee8a3d757402e2e0e40456', 'Full config save optimization', 2912 %>

--- a/source/partials/release_notes/_release-17-10-0.md.erb
+++ b/source/partials/release_notes/_release-17-10-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 12 Sep, 2017</div>
 **Important:** After the 17.9 release, we made an announcement asking users to hold off upgrading their GoCD instance. We found an issue (<%= link_to("#3834", "https://github.com/gocd/gocd/issues/#{3834}") %>) affecting a small set of users. This release provides a fix for the same.
 
 <h4>Critical Bug Fixes</h4>

--- a/source/partials/release_notes/_release-17-11-0.md.erb
+++ b/source/partials/release_notes/_release-17-11-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 30 Oct, 2017</div>
 <h4>UX Changes</h4>
 * <%= link_to_commit '67f1605fca894ea9855d16a283a913335200f3b2', 'Find Value Stream Map (VSM) more easily and show pipeline run duration in VSM', 3705%> (<%= link_to_issue 3858%>)
 

--- a/source/partials/release_notes/_release-17-12-0.md.erb
+++ b/source/partials/release_notes/_release-17-12-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 08 Dec, 2017</div>
 <h4>UX Changes</h4>
 * <%= link_to_commit '0e926106003a040ad4c62bc7810df0b851a35864', 'Newer plugins page', 4030%>.
 

--- a/source/partials/release_notes/_release-17-2-0.md.erb
+++ b/source/partials/release_notes/_release-17-2-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 21 Feb, 2017</div>
 <h4>Authorization Plugin Endpoint (beta)</h4>
 
 GoCD currently supports password-file, LDAP and plugin based authentication.

--- a/source/partials/release_notes/_release-17-3-0.md.erb
+++ b/source/partials/release_notes/_release-17-3-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 24 Mar, 2017</div>
 <h4>UI Enhancements </h4>
 
 * <%= link_to_commit '320f2236c9eec058d5a8dd35b17e021e56dac44c', 'Enhanched job/stage status accessibility with addition of symbols to signify stage and job statuses.', '3233' %>

--- a/source/partials/release_notes/_release-17-4-0.md.erb
+++ b/source/partials/release_notes/_release-17-4-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 26 Apr, 2017</div>
 <h4>UI Enhancements </h4>
 
 * <%= link_to_commit 'd6d59fb4a589acb7ef24416d8bb2eadea324bc3d', 'Enhanced console log view with an option to expand/collapse outputs of comamnds.', '3199' %>

--- a/source/partials/release_notes/_release-17-5-0.md.erb
+++ b/source/partials/release_notes/_release-17-5-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 02 Jun, 2017</div>
 <h4>Important</h4>
 
 There has been a critical security vulnerability identified with this release, fixes for the same have been provided in 17.7.0. If you are on 17.5.0, please upgrade immediately to 17.7.0 to keep your GoCD sever and agent secure.

--- a/source/partials/release_notes/_release-17-6-0.md.erb
+++ b/source/partials/release_notes/_release-17-6-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 27 Jun, 2017</div>
 <h4>Important</h4>
 
 There has been a critical security vulnerability identified with this release, fixes for the same have been provided in 17.7.0. If you are on 17.6.0, please upgrade immediately to 17.7.0 to keep your GoCD sever and agent secure.

--- a/source/partials/release_notes/_release-17-7-0.md.erb
+++ b/source/partials/release_notes/_release-17-7-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 28 Jun, 2017</div>
 <h4>Security Fixes</h4>
 
 **Important:** This release comes on the back of 17.6.0 as we have identified a critical security vulnerability with 17.5.0 and 17.6.0. If you are on 17.5.0 or 17.6.0, please upgrade immediately to this version to keep your GoCD server secure. We want to give sometime for users to upgrade before disclosing the details of the vulnerability.

--- a/source/partials/release_notes/_release-17-8-0.md.erb
+++ b/source/partials/release_notes/_release-17-8-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 02 Aug, 2017</div>
 <h4>Pipeline as Code</h4>
 
 With this release, GoCD supports [Pipeline as code](https://docs.gocd.org/current/advanced_usage/pipelines_as_code.html), out of the box. We've bundled the [JSON config repo plugin](https://github.com/tomzo/gocd-json-config-plugin) and the [YAML config repo plugin](https://github.com/tomzo/gocd-yaml-config-plugin) with the GoCD server.

--- a/source/partials/release_notes/_release-17-9-0.md.erb
+++ b/source/partials/release_notes/_release-17-9-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 05 Sep, 2017</div>
 <div class="warning" style="display: block">Sep 11 13:00 UTC 2017: We are investigating an issue (<%= link_to_issue "3834" %>) with upgrades affecting a small number of users. Please hold off on upgrading to 17.9.0 until further notice.</div>
 
 <h4>Improvements</h4>

--- a/source/partials/release_notes/_release-18-1-0.md.erb
+++ b/source/partials/release_notes/_release-18-1-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 24 Jan, 2018</div>
 <h4>Bug Fixes</h4>
 * <%= link_to_commit 'f9ad3990484ecf02bb4a888b9978748bd00b8e2b', 'Validate roles assigned to stage authorization on template update through API', 4185%> <%= link_to_issue 4176 %>
 * <%= link_to_commit '63d7d0f39663aa6e24d48e2c0ec99200d8733080', "Test artifacts configured using config-repo is uploaded to GoCD server's build artifacts' default location", 4083%> <%= link_to_issue 4071 %>

--- a/source/partials/release_notes/_release-18-10-0.md.erb
+++ b/source/partials/release_notes/_release-18-10-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 15 Oct, 2018</div>
 <h4>Support for Java 10 and 11</h4>
 
   While we continue to support Java 8, GoCD has now added support for Java 10 and 11. With Oracle moving towards a 6 month cadence for newer releases we are evaluating the process to keep in sync with the new cadence. Watch this space for more information in the coming releases.

--- a/source/partials/release_notes/_release-18-11-0.md.erb
+++ b/source/partials/release_notes/_release-18-11-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 26 Nov, 2018</div>
 <h4>Improvements</h4>
 
   * <%= link_to_commit '7203cb371a2ce06a18a7bbc5c2a317cd93a074cf', 'Allow artifact plugins to introduce new environment variables to be used by subsequent tasks.', 5188 %>

--- a/source/partials/release_notes/_release-18-12-0.md.erb
+++ b/source/partials/release_notes/_release-18-12-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 19 Dec, 2018</div>
 <h4>Manage Config Repositories through UI</h4>
 
 We have added a new Config Repositories page. This page lists existing config repos and allows CRUD (Create-Read-Update-Delete) operations for a config repo. This page has the ability to show errors and allows users to force a check of the repository.

--- a/source/partials/release_notes/_release-18-2-0.md.erb
+++ b/source/partials/release_notes/_release-18-2-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 08 Mar, 2018</div>
 <h4>New Dashboard Page (Beta)</h4>
 
 <figure class='shrink-figure-75'>

--- a/source/partials/release_notes/_release-18-3-0.md.erb
+++ b/source/partials/release_notes/_release-18-3-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 19 Apr, 2018</div>
 <h4>New Dashboard Page out of Beta</h4>
 After we released the improved GoCD Dashboard (beta) in 18.2.0, we made several bug fixes and performance improvements based on feedback from our users. The GoCD dashboard improves performance for large GoCD instances with thousands of pipelines. In 18.3.0, we have replaced the older version of the dashboard with this improved dashboard which will be available as the default option to all GoCD users.
 

--- a/source/partials/release_notes/_release-18-4-0.md.erb
+++ b/source/partials/release_notes/_release-18-4-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 09 May, 2018</div>
 <p class="information">
   Previously, there was a warning about not upgrading to 18.4. In 18.5, an issue around pipelines created using the pipeline config API showing twice on the dashboard was fixed. We haven't been able to replicate issue <%= link_to_issue 4723, '' %> around pipelines created using JSON and YAML plugins, we suspect it might be an issue with the individual's setup. [Updated: 2018 May 11, 11:45 UTC]
 </p>

--- a/source/partials/release_notes/_release-18-5-0.md.erb
+++ b/source/partials/release_notes/_release-18-5-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 11 May, 2018</div>
 <h4>Bug fixes</h4>
 
   * <%= link_to_issue 4724, "Fixed issue with duplicate pipeline instances showing on dashboard due to config-save operations via different methods." %>

--- a/source/partials/release_notes/_release-18-6-0.md.erb
+++ b/source/partials/release_notes/_release-18-6-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 11 Jun, 2018</div>
 <h4>Improvements</h4>
 
   * <%= link_to_commit '3541529f60044fec297f42efce08ca65d14651ad', 'Upgrade to TFS SDK version 14.118.0.' %>

--- a/source/partials/release_notes/_release-18-7-0.md.erb
+++ b/source/partials/release_notes/_release-18-7-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 23 Jul, 2018</div>
 <h4>External Artifacts</h4>
 
 Introduced support for publishing and fetching artifacts from an external artifacts store. 

--- a/source/partials/release_notes/_release-18-8-0.md.erb
+++ b/source/partials/release_notes/_release-18-8-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 04 Sep, 2018</div>
 <h4>Flexible & Personalized Dashboard</h4>
 
   We have made several improvements to the pipeline view on the new dashboard to make it more personal and relevant to our users.

--- a/source/partials/release_notes/_release-18-9-0.md.erb
+++ b/source/partials/release_notes/_release-18-9-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 11 Sep, 2018</div>
 <h4>Backups on a schedule</h4>
 
   This release allows performing a backup on schedule. GoCD now allows executing a script once the backup completes. This feature removes the need for GoCD administrators to execute and monitor custom "cron-like" jobs to ensure that backups are completed.

--- a/source/partials/release_notes/_release-19-1-0.md.erb
+++ b/source/partials/release_notes/_release-19-1-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 29 Jan, 2019</div>
 <h4> GoCD Maintenance mode </h4>
 
 GoCD maintenance mode can be utilized by the GoCD system administrator to safely restart or upgrade the GoCD server without having any running jobs reschedule when the server is back up. Initiating maintenance mode will cause various sub-systems of GoCD to stop working making sure server is not performing any operation.

--- a/source/partials/release_notes/_release-19-2-0.md.erb
+++ b/source/partials/release_notes/_release-19-2-0.md.erb
@@ -1,3 +1,4 @@
+<div class="release-date">Released on 06 Mar, 2019</div>
 <h4> Access Tokens </h4>
 
 We have introduced support for personal access tokens. GoCD users can now generate tokens through the application or the Access Token API and use them to access the GoCD APIs rather than passing their username & password. The tokens inherit the privileges of the user who created them.


### PR DESCRIPTION
Looks like this:

<img width="1156" alt="2019_04_24_19-44-37" src="https://user-images.githubusercontent.com/172235/56700798-10a22700-66ca-11e9-87e5-d32bfa93417e.png">

Fixes #963 

/cc @varshavaradarajan 

Dates from: https://github.com/gocd/gocd/releases