### PR TITLE
Add Java versions to release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ section.
 ## License
 
 ```plain
-Copyright 2018 ThoughtWorks, Inc.
+Copyright 2019 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/partials/next_release/_release.md.erb
+++ b/source/partials/next_release/_release.md.erb
@@ -1,5 +1,14 @@
 <h4>some feature</h4>
 
+<h4>Versions of Java this release of GoCD works with</h4>
+
+<ul>
+  <li>Java 8 (Deprecated)</li>
+  <li>Java 10 (Deprecated)</li>
+  <li>Java 11</li>
+  <li>Java 12</li>
+</ul>
+
 <h4>API Improvements</h4>
 
 

--- a/source/partials/release_notes/_release-19-4-0.md.erb
+++ b/source/partials/release_notes/_release-19-4-0.md.erb
@@ -14,9 +14,18 @@ Users can also utilize the newly introduced `branch` attribute on Mercurial mate
 
 <h4>Introduced support for Java 12</h4>
 
-Starting this release, GoCD has now added support for Java 12. All the docker images and installers for Windows and OSX are bundled with the supported Java versions.
+Starting this release, GoCD has now added support for Java 12. All the docker images and installers for Windows and OSX are bundled with a supported version of Java (not necessarily 12).
 
 Please refer this <%= link_to 'blogpost', 'https://www.gocd.org/2019/05/21/official-stance-on-java/' %> for our official stance on supported Java versions going forward.
+
+<h4>Versions of Java this release of GoCD works with</h4>
+
+<ul>
+  <li>Java 8 (Deprecated)</li>
+  <li>Java 10 (Deprecated)</li>
+  <li>Java 11</li>
+  <li>Java 12</li>
+</ul>
 
 <h4>API Improvements</h4>
 


### PR DESCRIPTION
Trying to be more clear in release notes, about supported Java versions.

See image in [comment below](https://github.com/gocd/www.go.cd/pull/987#issuecomment-497673267).