### PR TITLE
Soft remove AMIs

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -33,7 +33,6 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
             <li class="dropdown open">
               <span class="head">Cloud Providers</span>
               <ul>
-                <li><span class="tab-marker dld-ami" rel="tab-ami">AMIs</span></li>
                 <li><span class="tab-marker dld-docker" rel="tab-docker">Docker</span></li>
                 <li><span class="tab-marker dld-k8s" rel="tab-helm">Kubernetes/Helm</span></li>
               </ul>
@@ -435,7 +434,6 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
       <h3 class="tab-marker tab-accordion_heading dld-zip" rel="tab-zip">Zip</h3>
       {{> show-releases-for-installer-type installer_type="generic" os_type="zip" heading="Zip" tab_id="tab-zip"}}
       <h2 class="installer-type cloud">Cloud Providers</h2>
-      <h3 class="tab-marker tab-accordion_heading dld-ami" rel="tab-ami">AMIs</h3>
       {{> show-amis installer_type="ami" tab_id="tab-ami"}}
       <h3 class="tab-marker tab-accordion_heading dld-docker" rel="tab-docker">Docker</h3>
       {{> show-docker installer_type="docker" tab_id="tab-docker"}}


### PR DESCRIPTION
It's unlikely that it's being used much. No point keeping them around. Plan to "hard remove" on or around Aug 1.