### PR TITLE
Publish non root container blog post from draft to public

### DIFF
--- a/source/posts/2019-06-25-GoCD-non-root-containers.html.markdown.erb
+++ b/source/posts/2019-06-25-GoCD-non-root-containers.html.markdown.erb
@@ -8,7 +8,7 @@ summary_image: "/assets/images/blog/security-devops-minimizing-risk/security-dev
 title_tag_of_header: "Running Dockerized GoCD Containers as Non Root"
 meta_description: "Running Dockerized GoCD Containers as Non Root"
 meta_keywords: "GoCD, docker, containers, security, root, non-root"
-draft: true
+draft: false
 ---
 <% content_for :banner do %>
   <figure>


### PR DESCRIPTION
This needs to be merged at the time of `19.6.0` release