### PR TITLE
Add elastic agent extension v4 deprecation notice in 19.6.0 release notes

### DIFF
--- a/source/partials/release_notes/_release-19-6-0.md.erb
+++ b/source/partials/release_notes/_release-19-6-0.md.erb
@@ -81,6 +81,7 @@ In this release, a security issue responsibly disclosed by [Heinrich](https://ha
 
 <h4>Deprecations</h4>
 
+* The Elastic Agents plugin extension v4 has been deprecated. This version will be removed in a release scheduled for August 2019. Plugin developers should use version 5 of the plugin API.
 * The notification plugin extension version 3 has been deprecated. This version will be removed in an upcoming release. Plugin developers should use version 4 of the notification plugin api.
 * The analytics plugin extension version 1 has been deprecated. This version will be removed in an upcoming release. Plugin developers should use version 2 of the analytics plugin api.
 * The Get Server Info processor version 1 has been deprecated. This version will be removed in an upcoming release. Plugin developers should use version 2 of the Get Server Info processor.


### PR DESCRIPTION
\cc: @maheshp 

![Screen Shot 2019-07-22 at 6 08 36 PM](https://user-images.githubusercontent.com/15275847/61632976-bfdfa180-acab-11e9-8190-0c1e62c3c06c.png)
