### PR TITLE
Add AWS Ec2 plugin

### DIFF
--- a/data/plugins/elastic_agent_plugins.yml
+++ b/data/plugins/elastic_agent_plugins.yml
@@ -44,3 +44,12 @@
   releases_url: https://github.com/pikselpalette/gocd-elastic-agent-marathon/releases
   github_stars: http://ghbtns.com/github-btn.html?user=pikselpalette&repo=gocd-elastic-agent-marathon&type=watch&count=true
   first_available_date: 01/2017
+
+- name: GoCD Elastic agent plugin for AWS EC2
+  description: GoCD Elastic agent plugin for AWS EC2
+  readmore_url: https://github.com/continuumsecurity/GoCD-EC2-Elastic-Agent-Plugin
+  author_url: https://iriusrisk.com/
+  author_name: Continuum Security, S.L.
+  releases_url: https://github.com/continuumsecurity/GoCD-EC2-Elastic-Agent-Plugin/releases
+  github_stars: http://ghbtns.com/github-btn.html?user=continuumsecurity&repo=GoCD-EC2-Elastic-Agent-Plugin&type=watch&count=true
+  first_available_date: 12/2019


### PR DESCRIPTION
This PR adds AWS EC2 Elastic Agents plugin to the listing.