### PR TITLE
Show an ex_perimental docker images section

### DIFF
--- a/source/assets/javascripts/app/_download.js
+++ b/source/assets/javascripts/app/_download.js
@@ -9,7 +9,8 @@ var showDownloadLinks = (function ($) {
         version_to_show: function (release) {
           return release["go_version"];
         },
-        cloud_info_url: "https://download.gocd.org/cloud.json"
+        cloud_info_url: "https://download.gocd.org/cloud.json",
+        docker_org: 'gocd'
       },
       experimental: {
         download_info_url: "https://download.gocd.org/experimental/releases.json",
@@ -17,7 +18,8 @@ var showDownloadLinks = (function ($) {
         version_to_show: function (release) {
           return release["go_full_version"];
         },
-        cloud_info_url: "https://download.gocd.org/cloud.json"
+        cloud_info_url: "https://download.gocd.org/experimental/cloud.json",
+        docker_org: 'gocdexperimental'
       }
     };
 
@@ -157,6 +159,13 @@ var showDownloadLinks = (function ($) {
       var template = Handlebars.compile(
         $("#download-revisions-template").html()
       );
+
+      const assocDockerOrg = function (val) {
+        return R.assoc('docker_org', settings.docker_org, val);
+      };
+      // adding the docker organisation
+      latest_cloud_release = R.assoc('docker_org', settings.docker_org, latest_cloud_release);
+      other_cloud_releases = R.map(assocDockerOrg, other_cloud_releases);
 
       $("#downloads").html(
         template({

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -214,12 +214,18 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   <div id="{{{tab_id}}}" class="tab_content {{{installer_type}}}">
     <div class="latest">
       {{#with latest_cloud_release}}
+      <div class="release-type">
+        <input type="radio" id="stable-docker" name="typeOfDownloads-docker" checked="checked" value="stable" class="stable" />
+        <label for="stable-docker">Stable</label>
+        <input type="radio" id="experimental-docker" name="typeOfDownloads-docker" value="experimental" class="experimental" />
+        <label for="experimental-docker">Experimental</label>
+      </div>
       <div class="go-release {{go_version}} row">
         <div class=" col-xs-12">
           <span class="version">Version: {{go_version}}</span>
         </div>
         <div class="col-xs-12">
-          {{> show-docker-release server_docker=server_docker agents_docker=agents_docker}}
+          {{> show-docker-release server_docker=server_docker agents_docker=agents_docker docker_org=docker_org }}
         </div>
       </div>
       {{/with}}
@@ -234,7 +240,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
           <span class="version">Version: {{go_version}}</span>
         </div>
         <div class="col-xs-12">
-          {{> show-docker-release server_docker=server_docker agents_docker=agents_docker}}
+          {{> show-docker-release server_docker=server_docker agents_docker=agents_docker docker_org=docker_org }}
         </div>
       </div>
       {{/each}}
@@ -270,13 +276,13 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     <h3>GoCD Server Docker Image</h3>
     <ul class="docker-list server">
       {{#each server_docker}}
-      {{> show-server-docker-command image_name=image_name version=../go_version}}
+      {{> show-server-docker-command image_name=image_name version=../go_version docker_org=../docker_org }}
       {{/each}}
     </ul>
     <h3>GoCD Agent Docker Images</h3>
     <ul class="docker-list agents">
       {{#each agents_docker}}
-      {{> show-agent-docker-command image_name=image_name version=../go_version}}
+      {{> show-agent-docker-command image_name=image_name version=../go_version docker_org=../docker_org }}
       {{/each}}
     </ul>
   </div>
@@ -284,14 +290,14 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 
 
   {{#*inline "show-server-docker-command"}}
-  <li>More info at: <a href="https://hub.docker.com/r/gocd/{{image_name}}">{{image_name}}</a>
-    <span class="command">docker run -d -p8153:8153 -p8154:8154 gocd/{{image_name}}:v{{version}}</span>
+  <li>More info at: <a href="https://hub.docker.com/r/{{docker_org}}/{{image_name}}">{{image_name}}</a>
+    <span class="command">docker run -d -p8153:8153 -p8154:8154 {{docker_org}}/{{image_name}}:v{{version}}</span>
   </li>
   {{/inline}}
 
   {{#*inline "show-agent-docker-command"}}
-  <li>More info at: <a href="https://hub.docker.com/r/gocd/{{image_name}}">{{image_name}}</a>
-    <span class="command">docker run -d -e GO_SERVER_URL=... gocd/{{image_name}}:v{{version}}</span>
+  <li>More info at: <a href="https://hub.docker.com/r/{{docker_org}}/{{image_name}}">{{image_name}}</a>
+    <span class="command">docker run -d -e GO_SERVER_URL=... {{docker_org}}/{{image_name}}:v{{version}}</span>
   </li>
   {{/inline}}
 
@@ -378,7 +384,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
     });
 
     /* Switch between stable and experimental. */
-    target.on('change', 'input[type=radio][name=typeOfDownloads-rpm], input[type=radio][name=typeOfDownloads-deb], input[type=radio][name=typeOfDownloads-osx], input[type=radio][name=typeOfDownloads-win], input[type=radio][name=typeOfDownloads-generic]', function () {
+    target.on('change', 'input[type=radio][name=typeOfDownloads-rpm], input[type=radio][name=typeOfDownloads-deb], input[type=radio][name=typeOfDownloads-osx], input[type=radio][name=typeOfDownloads-win], input[type=radio][name=typeOfDownloads-generic], input[type=radio][name=typeOfDownloads-docker]', function () {
       currentInstallerType = $(this).val();
 
       showDownloadLinks({typeOfInstallersToShow: currentInstallerType})


### PR DESCRIPTION
Issue: #1136 

Added an experimental docker images section which points to `gocdexperimental/{image_name}`


P.S. - the weird title is go around the mergeable check