### PR TITLE
Clarify a part of the release notes

### DIFF
--- a/source/assets/javascripts/app/_download.js
+++ b/source/assets/javascripts/app/_download.js
@@ -100,7 +100,7 @@ var showDownloadLinks = (function ($) {
     var addReleaseDate = R.curry(function (release) {
       return R.assoc(
         "release_date",
-        new Date(release["release_time_readable"]).toDateString(),
+        new Date(release["release_time_readable"]).toDateString().substr(4),
         release
       );
     });

--- a/source/partials/release_notes/_release-20-5-0.md.erb
+++ b/source/partials/release_notes/_release-20-5-0.md.erb
@@ -1,6 +1,6 @@
 <h4>Support for multiple databases</h4>
 
-GoCD 20.5.0, while continuing to use H2 as the default database, introduces support for PostgreSQL without a need for the (previously used) commercial addon. As part of these changes GoCD moved away from using the unmaintained dbdeploy to liquibase for automated database migrations. These changes require a one-time manual migration of the GoCD database running on versions <= 20.4.0 to one compliant with GoCD 20.5.0 and beyond.
+GoCD 20.5.0, while continuing to use H2 as the default database, introduces support for PostgreSQL without a need for the (previously used) commercial addon. As part of these changes GoCD moved away from using the unmaintained dbdeploy to liquibase for automated database migrations. These changes require a one-time manual migration of the GoCD database running on versions <= 20.4.0 to one compliant with GoCD 20.5.0 and beyond, even if you decide not to migrate to PostgreSQL.
 
 Please refer to [the GoCD Database migration document](https://docs.gocd.org/20.5.0/installation/upgrade_to_gocd_20.5.0.html) for steps to migrate your database.
 


### PR DESCRIPTION
- Clarify that data migration is needed even if you decide not to move to PostgreSQL.
- Also: Remove the weekday from the release date in the downloads page.