### PR TITLE
Use Offical GoCD Helm Chart link

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -252,16 +252,16 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
   <div id="{{{tab_id}}}" class="tab_content {{{installer_type}}}">
     <h3>Running GoCD On Kubernetes</h3>
     <div class="command k8s">
-    <p>helm repo add stable https://kubernetes-charts.storage.googleapis.com</p>
+    <p>helm repo add gocd https://gocd.github.io/helm-chart</p>
     </div>
     <h4> For Helm 3 and above</h4>
     <div class="command k8s">
       <p>kubectl create ns gocd</p>
-      <p>helm install gocd stable/gocd --namespace gocd</p>
+      <p>helm install gocd gocd/gocd --namespace gocd</p>
     </div>
     <h4>For Helm 2</h4>
     <div class="command k8s">
-      <p>helm install --name gocd-app --namespace gocd stable/gocd</p>
+      <p>helm install --name gocd-app --namespace gocd gocd/gocd</p>
     </div>
     <div class="download-message k8s">
      <p>Refer to the <a href="https://docs.gocd.org/current/gocd_on_kubernetes">Getting Started Documentation</a> .</p>

--- a/source/kubernetes/index.html.erb
+++ b/source/kubernetes/index.html.erb
@@ -25,7 +25,7 @@ show_features: true
           </div>
         </a>
 
-        <a href="https://hub.kubeapps.com/charts/stable/gocd" TARGET="_blank">
+        <a href="https://hub.helm.sh/charts/gocd/gocd" TARGET="_blank">
           <div class="cta-button-ghost">
             <h3>GoCD HELM CHART</h3>
           </div>
@@ -111,7 +111,7 @@ show_features: true
             <h3>GET STARTED NOW</h3>
           </div>
         </a>
-        <a href="https://hub.kubeapps.com/charts/stable/gocd" TARGET="_blank">
+        <a href="https://hub.helm.sh/charts/gocd/gocd" TARGET="_blank">
           <div class="cta-button-ghost">
             <h3>GoCD HELM CHART</h3>
           </div>

--- a/source/posts/2018-03-21-continuous-delivery-gocd-kubernetes.html.markdown.erb
+++ b/source/posts/2018-03-21-continuous-delivery-gocd-kubernetes.html.markdown.erb
@@ -15,35 +15,35 @@ meta_keywords: "Gocd, kubernetes, cloud native, kubernetes plugin, gocd helm cha
   </figure>
 <% end %>
 
-We are excited to announce the [release of our Kubernetes helm chart](https://hub.kubeapps.com/charts/stable/gocd) that will allow our users to run GoCD natively on Kubernetes. 
+We are excited to announce the [release of our Kubernetes helm chart](https://hub.helm.sh/charts/gocd/gocd) that will allow our users to run GoCD natively on Kubernetes.
 
-GoCD is a best-of-breed continuous delivery tool that allows you to model complex continuous delivery workflows. Kubernetes has emerged as one of the most interesting application delivery platforms. Our upcoming releases will have features that allow GoCD users to model Docker based build workflows with deployments to Kubernetes - we’ll cover more about this later in the post.  
+GoCD is a best-of-breed continuous delivery tool that allows you to model complex continuous delivery workflows. Kubernetes has emerged as one of the most interesting application delivery platforms. Our upcoming releases will have features that allow GoCD users to model Docker based build workflows with deployments to Kubernetes - we’ll cover more about this later in the post.
 
 ## Continuous Delivery with Kubernetes
 
-An efficient continuous delivery (CD) workflow is key to enabling high performance teams deliver software frequently, and reliably. CD workflows are specific to an organization’s processes. One of the enablers of continuous delivery is a high level of automation with few manual interventions. And so, **automation around delivery infrastructure** is key to a successful CD workflow. 
+An efficient continuous delivery (CD) workflow is key to enabling high performance teams deliver software frequently, and reliably. CD workflows are specific to an organization’s processes. One of the enablers of continuous delivery is a high level of automation with few manual interventions. And so, **automation around delivery infrastructure** is key to a successful CD workflow.
 
 Kubernetes provides simple abstractions for designing deployments for modern application architectures without the need for a lot of ‘configuration management’ code. A powerful API makes it programmable and easily accessible to development teams. Though Kubernetes provides the platform to build self-service delivery infrastructure, it does not provide the facilities to build and deploy your applications.
 
-> _GoCD gives you the flexibility to effectively represent CD pipelines that suit your organization’s processes. Kubernetes gives you a highly programmable delivery infrastructure platform. And together, they provide the foundation for a powerful Continuous Delivery platform._ 
+> _GoCD gives you the flexibility to effectively represent CD pipelines that suit your organization’s processes. Kubernetes gives you a highly programmable delivery infrastructure platform. And together, they provide the foundation for a powerful Continuous Delivery platform._
 
-We wanted our users to be able to leverage GoCD’s pipeline modeling capabilities with Kubernetes’ developer-centric APIs to enhance their deployment process. To do this, we planned our Kubernetes-related feature releases in two steps. 
+We wanted our users to be able to leverage GoCD’s pipeline modeling capabilities with Kubernetes’ developer-centric APIs to enhance their deployment process. To do this, we planned our Kubernetes-related feature releases in two steps.
 
-## Step 1 (Current Release) : Run GoCD natively on Kubernetes 
+## Step 1 (Current Release) : Run GoCD natively on Kubernetes
 
 <img src="/assets/images/blog/gocd-kubernetes-helm-chart/kubernetes-cluster-agents.svg" alt="Provisioning GoCD Elastic Agents on a Kubernetes Cluster"/>
 
-Our first goal was to get GoCD to run natively on Kubernetes. In our latest release, we have provided our users with the ability to: 
+Our first goal was to get GoCD to run natively on Kubernetes. In our latest release, we have provided our users with the ability to:
 
-- Install GoCD as a Kubernetes native application with an officially supported helm chart 
-- Scale GoCD agents seamlessly with the new ElasticAgent plugin that spins up agents on the fly in response to build workload 
-- Design Docker-based build workflows using the Docker in Docker capability 
+- Install GoCD as a Kubernetes native application with an officially supported helm chart
+- Scale GoCD agents seamlessly with the new ElasticAgent plugin that spins up agents on the fly in response to build workload
+- Design Docker-based build workflows using the Docker in Docker capability
 
-## Step 2 (Upcoming Releases): Model a Docker-based build workflow 
+## Step 2 (Upcoming Releases): Model a Docker-based build workflow
 
 <img src="/assets/images/blog/gocd-kubernetes-helm-chart/GoCD-deploying-kubernetes.svg" alt="GoCD deploying to a Kubernetes Cluster"/>
 
-Beyond enabling GoCD to run natively on Kubernetes, we are also working on giving our users the ability to **fully leverage the container-based build workflow**. Containerization provides a clean separation of concerns for managing applications. Docker and Kubernetes together, enable a standard and simplified CD workflow. 
+Beyond enabling GoCD to run natively on Kubernetes, we are also working on giving our users the ability to **fully leverage the container-based build workflow**. Containerization provides a clean separation of concerns for managing applications. Docker and Kubernetes together, enable a standard and simplified CD workflow.
 
 These upcoming features will allow our users to:
 
@@ -51,13 +51,13 @@ These upcoming features will allow our users to:
 Docker images are the artifacts that are generated and propagated in a Docker based build workflow. Our users will be able to designate Docker images generated during the build process as artifacts. GoCD will even publish and fetch Docker images from a registry of choice. Metadata regarding Docker image artifacts will be made available to the build context for use in downstream pipelines.
 
 - **Deploy applications to a Kubernetes environment**<br/>
-Deployments to Kubernetes are based on deployment specifications that are hydrated with runtime configuration. This hydrated deployment specification is then applied to a Kubernetes cluster that performs the actual deployment of the application.  This capability will allow our users to compose these deployments in a continuous delivery build pipeline. 
+Deployments to Kubernetes are based on deployment specifications that are hydrated with runtime configuration. This hydrated deployment specification is then applied to a Kubernetes cluster that performs the actual deployment of the application.  This capability will allow our users to compose these deployments in a continuous delivery build pipeline.
 
 - **Monitor the deployment and call it done once the services come up**<br/>
-Kubernetes provides a rich API to monitor the progress of a deployment and provide the status of running applications. With this capability, a GoCD build task will complete once the Kubernetes deployment has completed. This will allow for reliably triggering post-deployment stages. 
+Kubernetes provides a rich API to monitor the progress of a deployment and provide the status of running applications. With this capability, a GoCD build task will complete once the Kubernetes deployment has completed. This will allow for reliably triggering post-deployment stages.
 
 ---
 
-We've built GoCD to encompass the best CD practices. We’ve always tried to stay true to that with every release we make and the Kubernetes plugin is no exception. 
+We've built GoCD to encompass the best CD practices. We’ve always tried to stay true to that with every release we make and the Kubernetes plugin is no exception.
 
-Check out our [documentation on how to start using GoCD on Kubernetes](https://docs.gocd.org/current/gocd_on_kubernetes/) with our officially supported [helm chart](https://hub.kubeapps.com/charts/stable/gocd) now. 
+Check out our [documentation on how to start using GoCD on Kubernetes](https://docs.gocd.org/current/gocd_on_kubernetes/) with our officially supported [helm chart](https://hub.helm.sh/charts/gocd/gocd) now.

--- a/source/posts/2018-10-16-new-gocd-features.html.markdown.erb
+++ b/source/posts/2018-10-16-new-gocd-features.html.markdown.erb
@@ -8,7 +8,7 @@ summary_image: "/assets/images/blog/whats-new-gocd/gocd-new-features.jpg"
 title_tag_of_header: "What's New in GoCD | GoCD Blog"
 meta_description: "GoCD supports cloud native infrastructures, pipelines as code, and on demand agents."
 meta_keywords: "cloud native, kubernetes, docker, elastic agents, on demand agents, pipeline as code, config as code"
-tags: 
+tags:
 ---
 <% content_for :banner do %>
   <figure>
@@ -25,11 +25,11 @@ We’ve built two distinct sets of features to make GoCD cloud native. First, we
 
 ###Operating on cloud infrastructure
 
-People operating CI and CD servers on cloud providers want to perform as little administration of their build infrastructure as possible. Getting started should be easy. Build resources, or agents in GoCD parlance, should scale up and down transparently, as needed. GoCD addresses this with a suite of “elastic agent” plugins that provide scalable build infrastructure on Amazon ECS, Docker, Docker Swarm, OpenStack, and of course, Kubernetes. 
+People operating CI and CD servers on cloud providers want to perform as little administration of their build infrastructure as possible. Getting started should be easy. Build resources, or agents in GoCD parlance, should scale up and down transparently, as needed. GoCD addresses this with a suite of “elastic agent” plugins that provide scalable build infrastructure on Amazon ECS, Docker, Docker Swarm, OpenStack, and of course, Kubernetes.
 
 Veteran users of GoCD likely have spent a fair bit of time managing their agent grids via scripts, puppet, chef and similar. An elastic agent plugin eliminates this work as GoCD installs, starts, and stops agents as needed on whatever cloud provider you point it at.
 
-On Kubernetes, we've provided a [helm chart](https://hub.kubeapps.com/charts/stable/gocd) to make it near trivial to install and operate GoCD in its entirety on your Kubernetes cluster.
+On Kubernetes, we've provided a [helm chart](https://hub.helm.sh/charts/gocd/gocd) to make it near trivial to install and operate GoCD in its entirety on your Kubernetes cluster.
 
 Check out more about:
 
@@ -45,7 +45,7 @@ Check out more about:
 There are two elements to our improved container based workflows:
 
 1. Teams who are fully immersed in Docker want pretty much everything to be Docker-based.  If you are utilizing our Docker, ECS Docker or Kubernetes support then all your build activity will now be Docker based. It just works.
-2. GoCD now supports Docker images as native GoCD artifacts.  GoCD abides by "build once and only once" and provides full traceability up and downstream for artifacts. You can now  specify a Docker image repository as a GoCD artifact repository. This allows Docker images to be a part of GoCD’s native artifact tracing, pushing, and fetching. 
+2. GoCD now supports Docker images as native GoCD artifacts.  GoCD abides by "build once and only once" and provides full traceability up and downstream for artifacts. You can now  specify a Docker image repository as a GoCD artifact repository. This allows Docker images to be a part of GoCD’s native artifact tracing, pushing, and fetching.
 
 ##Analytics plugin for enterprise users
 
@@ -55,19 +55,19 @@ One of the highlights, is when you're looking at your value stream, you can pick
 
 <img src="/assets/images/blog/whats-new-gocd/gocd-analytics-vsm.png" alt="CD Pipeline Analytics"/>
 
-Another supported use case is to view your pipeline trends and identify builds that are slowing down. GoCD allows you to drill down to different levels of your pipeline to find root causes, e.g. slow tests or a lack of resources. 
+Another supported use case is to view your pipeline trends and identify builds that are slowing down. GoCD allows you to drill down to different levels of your pipeline to find root causes, e.g. slow tests or a lack of resources.
 
 The GoCD enterprise offering provides you add-on software and support from the core team to enable GoCD for larger enterprise environments.
 
-##Improved the main dashboard 
+##Improved the main dashboard
 
-We have also made a couple of dashboard improvements. First, we improved performance for big organizations with hundreds or thousands of pipelines. Second, we have added personalization to the dashboard. You can now filter the dashboard to show only specific pipelines and pipeline groups. And you can save those settings as custom dashboard tabs for future reference. 
+We have also made a couple of dashboard improvements. First, we improved performance for big organizations with hundreds or thousands of pipelines. Second, we have added personalization to the dashboard. You can now filter the dashboard to show only specific pipelines and pipeline groups. And you can save those settings as custom dashboard tabs for future reference.
 
 <img src="/assets/images/blog/whats-new-gocd/gocd-dashboard.gif" alt="GoCD Dashboard"/>
 
 ##Pipelines as code
 
-In case you missed it, another cool feature we have improved over the past year is “[Pipelines as code](https://www.gocd.org/2017/05/02/what-does-pipelines-as-code-really-mean/)”. With this feature, you can store your pipeline configuration as YAML or JSON files in your own repository, so that you can modify, control and version it externally. 
+In case you missed it, another cool feature we have improved over the past year is “[Pipelines as code](https://www.gocd.org/2017/05/02/what-does-pipelines-as-code-really-mean/)”. With this feature, you can store your pipeline configuration as YAML or JSON files in your own repository, so that you can modify, control and version it externally.
 
 We also exposed this ability as a plugin endpoint so anyone can write a plugin for a config repository, to store the configuration in any manner you choose. For more in depth reading on  GoCD’s pipeline as code feature, please [visit our documentation](https://docs.gocd.org/current/advanced_usage/pipelines_as_code.html) for more details.
 

--- a/source/posts/2019-05-14-installing-configuring-gocd-gke-using-helm.html.markdown.erb
+++ b/source/posts/2019-05-14-installing-configuring-gocd-gke-using-helm.html.markdown.erb
@@ -33,7 +33,7 @@ You can create the cluster using multiple options. You can use
 You can specify the zone, GKE master version, the machine type and number of nodes among other things as per your requirements. Remember to allocate enough vCPUs and RAM to run the GoCD server as well as the agents.
 
 ##**Deploy GoCD**
-GoCD provides a [helm](https://github.com/gocd/helm-charts/tree/master/gocd) chart to deploy GoCD easily in a cluster. You can also find a basic [tutorial](https://docs.gocd.org/current/gocd_on_kubernetes/gocd_helm_chart/helm_install.html) here which I’m repeating for better continuity.
+GoCD provides a [helm](https://github.com/gocd/helm-chart/tree/master/gocd) chart to deploy GoCD easily in a cluster. You can also find a basic [tutorial](https://docs.gocd.org/current/gocd_on_kubernetes/gocd_helm_chart/helm_install.html) here which I’m repeating for better continuity.
 
 1) First you have to set the correct context so that we are able to deploy GoCD in the correct cluster.
 

--- a/source/posts/2019-05-14-installing-configuring-gocd-gke-using-helm.html.markdown.erb
+++ b/source/posts/2019-05-14-installing-configuring-gocd-gke-using-helm.html.markdown.erb
@@ -33,7 +33,7 @@ You can create the cluster using multiple options. You can use
 You can specify the zone, GKE master version, the machine type and number of nodes among other things as per your requirements. Remember to allocate enough vCPUs and RAM to run the GoCD server as well as the agents.
 
 ##**Deploy GoCD**
-GoCD provides a [helm](https://github.com/helm/charts/tree/master/stable/gocd) chart to deploy GoCD easily in a cluster. You can also find a basic [tutorial](https://docs.gocd.org/current/gocd_on_kubernetes/gocd_helm_chart/helm_install.html) here which I’m repeating for better continuity.
+GoCD provides a [helm](https://github.com/gocd/helm-charts/tree/master/gocd) chart to deploy GoCD easily in a cluster. You can also find a basic [tutorial](https://docs.gocd.org/current/gocd_on_kubernetes/gocd_helm_chart/helm_install.html) here which I’m repeating for better continuity.
 
 1) First you have to set the correct context so that we are able to deploy GoCD in the correct cluster.
 
@@ -62,13 +62,13 @@ kubectl create clusterrolebinding clusterRoleBinding \
 
 
 ~~~
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add gocd https://gocd.github.io/helm-chart
 ~~~
 
 5) Now, all we have to do is just install the chart as
 
 ~~~
-helm install stable/gocd —- name gocd —- namespace gocd
+helm install gocd/gocd —- name gocd —- namespace gocd
 ~~~
 
 This will install GoCD on your server along with an ingress to allow access to the Go server over the internet.
@@ -84,10 +84,10 @@ kubectl get ingress --namespace gocd gocd-server -o jsonpath=
 
 If you go to the server you’ll be able to see the GoCD dashboard with a *hello-world* pipeline executed just to verify if everything works.
 
-But executing the above command configures the Go server using the values available in this values.yaml file. If you are just playing around to get a feel of using GoCD in Kubernetes, this is fine. However if you are trying to configure the GoCD server with some basic options, then it’s better to use your own [values.yaml](https://github.com/helm/charts/blob/master/stable/gocd/values.yaml) file as follows
+But executing the above command configures the Go server using the values available in this values.yaml file. If you are just playing around to get a feel of using GoCD in Kubernetes, this is fine. However if you are trying to configure the GoCD server with some basic options, then it’s better to use your own [values.yaml](https://github.com/gocd/helm-chart/blob/master/gocd/values.yaml) file as follows
 
 ~~~
-helm install —- name gocd-app —- namespace gocd -f values.yaml stable/gocd
+helm install —- name gocd-app —- namespace gocd -f values.yaml gocd/gocd
 ~~~
 
 ##**Configuring Password File based Authentication**

--- a/source/posts/2019-09-17-configure-gocd-agents-kubernetes-static-elastic.html.markdown.erb
+++ b/source/posts/2019-09-17-configure-gocd-agents-kubernetes-static-elastic.html.markdown.erb
@@ -54,7 +54,7 @@ Every time a new tool or package is to be added to the agent, a new image can be
 1. The given repository should be public. If a private repository is used, then the Go server should have access to it. I have mentioned how to configure access for a private repository using the Docker Artifact Store plugin here.
 2. All agents that are created after applying the values will be in a pending state. They have to be manually enabled.*
 
-There are many other configuration options available in the [values.yaml](https://github.com/helm/charts/blob/master/stable/gocd/values.yaml) that can be used to configure the agents. One important example is the security.ssh section that allows us to mount a SSH files using a kubernetes secret. This can be used to allow access to various VCS that use SSH to control access. I’ve explained it in a little more detail in the first post of this series. You can also specify the [storage](https://github.com/helm/charts/blob/480ad2744095a7ca62699c7cd97d20e2491a4852/stable/gocd/values.yaml#L268), [memory as well as maximum CPU allocation](https://github.com/helm/charts/blob/480ad2744095a7ca62699c7cd97d20e2491a4852/stable/gocd/values.yaml#L348) for the agents.
+There are many other configuration options available in the [values.yaml](https://github.com/gocd/helm-chart/blob/master/gocd/values.yaml) that can be used to configure the agents. One important example is the security.ssh section that allows us to mount a SSH files using a kubernetes secret. This can be used to allow access to various VCS that use SSH to control access. I’ve explained it in a little more detail in the first post of this series. You can also specify the [storage](https://github.com/gocd/helm-chart/blob/master/gocd/values.yaml), [memory as well as maximum CPU allocation](https://github.com/gocd/helm-chart/blob/master/gocd/values.yaml) for the agents.
 
 ##Elastic Agents:
 
@@ -144,6 +144,6 @@ As you can see the pod spec has been specified in YAML. You will have to set the
 If you want the pod to have SSH access to a Git service, you can create a secret with the SSH files and then mount it like shown in the pod spec above. Doing this should give your elastic agents access to your Git repositories.
 
 So there you go. I hope you find it useful. If you have any questions, please feel free to comment and I’ll answer from whatever I’ve learnt so far.
-        
+
 *This article was originally posted on [Mohamed Najiullah's blog](https://mohamednajiullah.tech/configuring-go-agents-in-gocd-in-kubernetes-static-and-elastic-agents-c5dbf5f6a01d)*
 

--- a/source/posts/2020-04-14-gocd-on-kubernetes-using-terraform.html.markdown.erb
+++ b/source/posts/2020-04-14-gocd-on-kubernetes-using-terraform.html.markdown.erb
@@ -153,7 +153,7 @@ resource "kubernetes_namespace" "gocd_namespace" {
 ~~~
 resource "helm_release" "gocd" {
   name = "gocd"
-  chart = "stable/gocd"
+  chart = "gocd/gocd"
   namespace = kubernetes_namespace.gocd_namespace.metadata.0.name
   depends_on = [kubernetes_namespace.gocd_namespace]
 }


### PR DESCRIPTION
* Use GoCD Helm Chart repository instead.
* Change docs to use gocd/gocd instead of stable/gocd.
* Point to hub.helm.sh gocd helm chart.
* Fix various links pointing to charts yaml from stable/gocd.