### PR TITLE
Adding new SCM plugin "gocd-ftp-server-plugin" on the plugin pages

### DIFF
--- a/data/plugins/scm_plugins.yml
+++ b/data/plugins/scm_plugins.yml
@@ -69,3 +69,12 @@
   releases_url: https://github.com/kszatan/gocd-phabricator-staging-material/releases
   github_stars: https://ghbtns.com/github-btn.html?user=kszatan&repo=gocd-phabricator-staging-material&type=star&count=true
   first_available_data: 07/2017
+
+- name: FTP Server SCM
+  description: Plugin that downloads the source codes/files from FTP Server from a configured directory path.
+  readmore_url: https://github.com/sekhar-rangam/gocd-ftp-server-plugin
+  author_url: https://github.com/sekhar-rangam
+  author_name: Sekhar Rangam
+  releases_url: https://github.com/sekhar-rangam/gocd-ftp-server-plugin/releases
+  github_stars: https://ghbtns.com/github-btn.html?user=sekhar-rangam&repo=gocd-ftp-server-plugin&type=star&count=true
+  first_available_data: 02/2021


### PR DESCRIPTION
Developed a new SCM plugin to integrate the GoCD server pipeline with FTP server to download all source codes, this plugin helps when there is no access to Git in deployment environment or when you want to package source code along with containers in production environment to protect IP/License/Copy rights