### PR TITLE
GitHub Actions build fails due to a sassc issue

### DIFF
--- a/.github/workflows/build_and_preview.yml
+++ b/.github/workflows/build_and_preview.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_BUILD__SASSC: --disable-march-tune-native
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/build_and_preview.yml
+++ b/.github/workflows/build_and_preview.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_BUILD__SASSC: --disable-march-tune-native
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ PLATFORMS
   x86_64-darwin-18
 
 
+
 DEPENDENCIES
   bootstrap-sass
   bourbon


### PR DESCRIPTION
Thought this was a simple issue and tried to push commits directly to master (see commits around https://github.com/gocd/www.go.cd/commit/77044deacd84f49007c418e15d82f7a05d6734d4). Will try on this PR instead.