### PR TITLE
plugins: update config repo groovy plugin urls

### DIFF
--- a/data/plugins/config_repo_plugins.yml
+++ b/data/plugins/config_repo_plugins.yml
@@ -18,10 +18,9 @@
 
 - name: gocd-groovy-dsl-config-plugin
   description: A plugin to keep pipelines and environments configuration in source-control in Groovy.
-  readmore_url: https://github.com/ketan/gocd-groovy-dsl-config-plugin
+  readmore_url: https://github.com/gocd-contrib/gocd-groovy-dsl-config-plugin
   author_url: https://github.com/ketan
   author_name: Ketan Padegaonkar
-  releases_url: https://github.com/ketan/gocd-groovy-dsl-config-plugin/releases
-  github_stars: http://ghbtns.com/github-btn.html?user=ketan&repo=gocd-groovy-dsl-config-plugin&type=watch&count=true
+  releases_url: https://github.com/gocd-contrib/gocd-groovy-dsl-config-plugin/releases
+  github_stars: http://ghbtns.com/github-btn.html?user=gocd-contrib&repo=gocd-groovy-dsl-config-plugin&type=watch&count=true
   first_available_date: 02/2018
-


### PR DESCRIPTION
It seems like https://github.com/ketan/gocd-groovy-dsl-config-plugin is not actively maintained.
-> Switch to https://github.com/gocd-contrib/gocd-groovy-dsl-config-plugin

@ketan I hope it's fine with you.