### PR TITLE
Update Download URL for SonarQube Quality Gate Task plugin

### DIFF
--- a/data/plugins/task_plugins.yml
+++ b/data/plugins/task_plugins.yml
@@ -165,7 +165,7 @@
   readmore_url: https://github.com/Haufe-Lexware/gocd-plugins/wiki/SonarQube-Quality-Gates-Task-Plugin
   author_url: https://github.com/markus2810
   author_name: Markus Wehrle
-  releases_url: https://github.com/Haufe-Lexware/gocd-plugins/releases
+  releases_url: https://github.com/Haufe-Lexware/gocd-plugins/tree/master/sonar-qualitygates-plugin/jar
   github_stars: http://ghbtns.com/github-btn.html?user=Haufe-Lexware&repo=gocd-plugins&type=watch&count=true
   first_available_date: 12/2015
 


### PR DESCRIPTION
Fixes #1223. Note that this is a non GH release now, and that these plugins are deprecated/unmaintained.