### PR TITLE
Remove unnecessary Windows 64-bit note

### DIFF
--- a/source/assets/javascripts/app/_download.js
+++ b/source/assets/javascripts/app/_download.js
@@ -129,7 +129,6 @@ var showDownloadLinks = (function ($) {
     var showReleases = function (releaseData, cloudData) {
       var addInfo = function (latestRelease) {
         var notes = {
-          win: "GoCD server and agent installers for Windows are packaged with 64 bit JRE. Starting with GoCD release v18.12.0, GoCD server and agent windows installers will not be shipped with 32 bit JRE.",
           deb: 'Note: If you prefer to use the APT repository to install, please follow these <a href="https://docs.gocd.org/current/installation/install/server/linux.html#debian-based-distributions-ie-ubuntu">instructions</a>.',
           rpm: 'Note: If you prefer to use the YUM repository to install, please follow these <a href="https://docs.gocd.org/current/installation/install/server/linux.html#rpm-based-distributions-ie-redhatcentosfedora">instructions</a>.'
         };


### PR DESCRIPTION
Fixes #850 - removes outdated note from Windows downloads.