### PR TITLE
Remove suggestion to expose port 8154 when running Docker images

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -291,7 +291,7 @@ meta_keywords: "GoCD download, go agent download, go cd download, install gocd"
 
   {{#*inline "show-server-docker-command"}}
   <li>More info at: <a href="https://hub.docker.com/r/{{docker_org}}/{{image_name}}">{{image_name}}</a>
-    <span class="command">docker run -d -p8153:8153 -p8154:8154 {{docker_org}}/{{image_name}}:v{{version}}</span>
+    <span class="command">docker run -d -p8153:8153 {{docker_org}}/{{image_name}}:v{{version}}</span>
   </li>
   {{/inline}}
 


### PR DESCRIPTION
This has been removed from [Docker Hub instructions](https://hub.docker.com/r/gocd/gocd-server) already. Exposing TLS port was removed in 20.6.0 which has aged off the download page already.

https://github.com/gocd/gocd/issues/7872