### PR TITLE
Missed from release notes the switch to Debian slim for agent images

### DIFF
--- a/source/partials/release_notes/_release-21-4-0.md.erb
+++ b/source/partials/release_notes/_release-21-4-0.md.erb
@@ -17,6 +17,7 @@ We do not have evidence that the upgraded dependencies pose any specific risk in
 
 * <%= link_to_issue 9828, 'Build the default GoCD Server image on Alpine 3.14' %>
 * <%= link_to_issue 9966, 'Migrate Centos 8 Agent and Server images to Centos Stream' %>
+* <%= link_to_issue 9922, 'Base Debian agent images on "slim" variants' %>
 * Starting this release, Alpine 3.15 based docker images for GoCD Agent are <%= link_to 'available', 'https://hub.docker.com/r/gocd/gocd-agent-alpine-3.15' %>.
 * Starting this release, Debian 11 based docker images for GoCD Agent are <%= link_to 'available', 'https://hub.docker.com/r/gocd/gocd-agent-debian-11' %>.
 


### PR DESCRIPTION
Add missing item to release notes for 21.4.0