### PR TITLE
Revert "Bump concurrent-ruby from 1.3.4 to 1.3.5"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.4)
     console (1.29.2)
       fiber-annotation
       fiber-local (~> 1.1)


### PR DESCRIPTION
Reverts gocd/www.go.cd#1832