### PR TITLE
Simplify workflows and remove PR-review previews

### DIFF
--- a/.github/workflows/build_and_preview.yml
+++ b/.github/workflows/build_and_preview.yml
@@ -12,8 +12,6 @@ permissions:
   contents: read
 
 env:
-  RUBYOPT: -W0 # needed to not print the warnings - makes the logs too big
-  BUNDLE_BUILD__SASSC: --disable-march-tune-native
   RUN_EXTERNAL_CHECKS: true
 
 jobs:
@@ -24,12 +22,9 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: false # true would run bundle install
+          bundler-cache: true
       - name: Run the build
-        run: |
-          bundle config --local build.sassc --disable-march-tune-native
-          bundle install
-          bundle exec rake build --verbose
+        run: bundle exec rake build --verbose
   push_to_gh_pages:
     needs: complete_build
     runs-on: ubuntu-latest
@@ -40,7 +35,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: false # true would run bundle install
+          bundler-cache: true
       - name: Set up user in git config
         env:
           USER: "${{ secrets.GH_PREVIEW_WRITE_USER }}"
@@ -54,8 +49,6 @@ jobs:
           aws-region: "${{ secrets.AWS_REGION }}"
       - name: Set up upstream and publish to gh pages
         run: |
-          bundle config --local build.sassc --disable-march-tune-native
-          bundle install
           git remote add preview https://${USER}:${TOKEN}@github.com/gocd/preview.go.cd.git
           bundle exec rake publish --trace
         env:

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -5,37 +5,19 @@ name: Testing For PRs
 on: [ pull_request ]
 
 env:
-  RUBYOPT: -W0 # needed to not print the warnings - makes the logs too big
   RUN_EXTERNAL_CHECKS: true
 
 jobs:
-  build_and_push_to_preview:
+  complete_build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true # would run bundle install
-      - name: Set up user in git config
-        env:
-          USER: "${{ secrets.GH_PREVIEW_WRITE_USER }}"
-        run: |
-          git config --global user.name "${USER}"
-          git config --global user.email "${USER}@github.com"
+          bundler-cache: true
       - name: Run the build
         run: bundle exec rake build --verbose
       - name: Build failed
         if: ${{ failure() }}
         run: bundle exec middleman build --verbose
-      - name: Push to preview
-        run: |
-          export PR_NO=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          git clone --depth=1 --branch=gh-pages "https://${USER}:${TOKEN}@github.com/gocd/pr-review.gocd.org" website
-          rm -rf website/pr-${PR_NO}
-          mv build website/pr-${PR_NO}
-          cd website && git config core.filemode false && git add -A .
-          git commit -m "Update website to ${PR_NO}" && git push
-        env:
-          USER: "${{ secrets.GH_PREVIEW_WRITE_USER }}"
-          TOKEN: "${{ secrets.GH_PREVIEW_WRITE_USER_ACCESS_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,6 @@ permissions:
   id-token: write
   contents: write
 
-env:
-  RUBYOPT: -W0 # needed to not print the warnings - makes the logs too big
-
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
@@ -26,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: false # true would run bundle install
+          bundler-cache: true
       - name: Set up user in git config
         run: |
           git config --global user.name "${USER}"
@@ -38,8 +35,6 @@ jobs:
           aws-region: "${{ secrets.AWS_REGION }}"
       - name: Set up upstream and publish to gh pages
         run: |
-          bundle config --local build.sassc --disable-march-tune-native
-          bundle install
           git remote add real https://${USER}:${TOKEN}@github.com/gocd/www.go.cd.git
           bundle exec rake publish --trace
         env:


### PR DESCRIPTION
This repo is too painful to manaage via GH pages; the actions usually fail due to race conditions and it's generally not worth the hassle. Easy to build a PR locally if there is risk; or just rely on preview.gocd.org from master.